### PR TITLE
Option for external ptrie install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,17 +33,19 @@ if (PDAAAL_GetDependencies)
     include(ExternalProject)
     set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/external)
 
-    ExternalProject_add(ptrie-ext
-            URL https://github.com/petergjoel/ptrie/archive/v1.1.0.zip
-            URL_HASH SHA512=092a8f50ca21d1199b19a10c4e0273c93a717a9f6491998a16bf21d21d37e6537ffd8a06ac41a2b623241da6036546d44b754567441944565e2a16646378cf29
-            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION} -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
-            )
-    file(MAKE_DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/include)
-
+    if (PTRIE_INSTALL_DIR)
+        include_directories(${PTRIE_INSTALL_DIR})
+    else()
+        ExternalProject_add(ptrie-ext
+                URL https://github.com/petergjoel/ptrie/archive/v1.1.0.zip
+                URL_HASH SHA512=092a8f50ca21d1199b19a10c4e0273c93a717a9f6491998a16bf21d21d37e6537ffd8a06ac41a2b623241da6036546d44b754567441944565e2a16646378cf29
+                CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION} -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+                )
+        file(MAKE_DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/include)
+    endif()
     # we can now include external libraries
     include_directories(${EXTERNAL_INSTALL_LOCATION}/include)
     link_directories(${EXTERNAL_INSTALL_LOCATION}/lib)
-
 endif (PDAAAL_GetDependencies)
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,12 @@ project(PDAAAL C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-add_library(pdaaal pdaaal/PDA.h pdaaal/PDA.cpp pdaaal/Reducer.h pdaaal/Reducer.cpp ${HEADER_FILES})
-add_dependencies(pdaaal ptrie-ext)
+add_library(pdaaal ${HEADER_FILES} pdaaal/PDA.cpp pdaaal/Reducer.cpp)
+
+if (NOT PTRIE_INSTALL_DIR)
+    add_dependencies(pdaaal ptrie-ext)
+endif()
+
 target_include_directories (pdaaal PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(TARGETS pdaaal
@@ -12,4 +16,3 @@ install(TARGETS pdaaal
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 install (FILES pdaaal/NFA.h pdaaal/Weight.h pdaaal/PDA.h pdaaal/PDAAdapter.h pdaaal/PDAFactory.h pdaaal/SimplePDAFactory.h pdaaal/TypedPDA.h pdaaal/PAutomaton.h pdaaal/Solver.h pdaaal/SolverAdapter.h pdaaal/Reducer.h DESTINATION include/pdaaal)
-


### PR DESCRIPTION
If PTRIE_INSTALL_DIR is set, PDAAAL will use this version of ptrie rather than installing it itself. 
For projects that use both ptrie and PDAAAL, this makes it possible to reduce the number of times ptrie is downloaded and installed. 