### PR TITLE
Reorder the reduction lvl

### DIFF
--- a/src/pdaaal/Reducer.h
+++ b/src/pdaaal/Reducer.h
@@ -71,7 +71,7 @@ namespace pdaaal {
             Reducer::forwards_prune(pda, initial_id);
             Reducer::backwards_prune(pda, terminal_id);
             std::queue<size_t> waiting;
-            auto ds = (aggresivity >= 2 && aggresivity <= 3);
+            auto ds = (aggresivity == 2 || aggresivity == 4);
             std::vector<tos_t> approximation(pda.states().size());
             // initialize
             for (const auto& [r,labels] : pda.states()[initial_id]._rules) {


### PR DESCRIPTION
Aggresivity 2 and 4 will enforce simple and dual stack reduction, 3 is simple and target-tos, and 4 use redcution 2 and target-tos.