### PR TITLE
New PDA construction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,5 +16,5 @@ install(TARGETS pdaaal
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
 install (FILES pdaaal/vector_set.h pdaaal/fut_set.h pdaaal/NFA.h pdaaal/Weight.h pdaaal/PDA.h pdaaal/PDAAdapter.h pdaaal/PDAFactory.h
-        pdaaal/SolverInstance.h
+        pdaaal/NewPDAFactory.h pdaaal/SolverInstance.h
         pdaaal/SimplePDAFactory.h pdaaal/TypedPDA.h pdaaal/PAutomaton.h pdaaal/Solver.h pdaaal/SolverAdapter.h pdaaal/Reducer.h DESTINATION include/pdaaal)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,4 +15,6 @@ install(TARGETS pdaaal
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
-install (FILES pdaaal/vector_set.h pdaaal/fut_set.h pdaaal/NFA.h pdaaal/Weight.h pdaaal/PDA.h pdaaal/PDAAdapter.h pdaaal/PDAFactory.h pdaaal/SimplePDAFactory.h pdaaal/TypedPDA.h pdaaal/PAutomaton.h pdaaal/Solver.h pdaaal/SolverAdapter.h pdaaal/Reducer.h DESTINATION include/pdaaal)
+install (FILES pdaaal/vector_set.h pdaaal/fut_set.h pdaaal/NFA.h pdaaal/Weight.h pdaaal/PDA.h pdaaal/PDAAdapter.h pdaaal/PDAFactory.h
+        pdaaal/SolverInstance.h
+        pdaaal/SimplePDAFactory.h pdaaal/TypedPDA.h pdaaal/PAutomaton.h pdaaal/Solver.h pdaaal/SolverAdapter.h pdaaal/Reducer.h DESTINATION include/pdaaal)

--- a/src/pdaaal/NFA.h
+++ b/src/pdaaal/NFA.h
@@ -194,7 +194,7 @@ namespace pdaaal {
         [[nodiscard]] bool empty_accept() const {
             assert(std::is_sorted(_initial.begin(), _initial.end()));
             // Also assume that follow_epsilon(_initial) has been executed (e.g. in compile()).
-            return std::any_of(_initial.begin(), _initial.end(), [](const state_t* s){ return s->accepting; });
+            return std::any_of(_initial.begin(), _initial.end(), [](const state_t* s){ return s->_accepting; });
         }
 
         template<typename C>
@@ -397,8 +397,8 @@ namespace pdaaal {
             out << "}\n";
         }
 
-        const std::vector<state_t*>& initial() { return _initial; }
-        const std::vector<state_t*>& accepting() { return _accepting; }
+        const std::vector<state_t*>& initial() const { return _initial; }
+        const std::vector<state_t*>& accepting() const { return _accepting; }
         const std::vector<std::unique_ptr<state_t>>& states() { return _states; }
         
     private:

--- a/src/pdaaal/NFA.h
+++ b/src/pdaaal/NFA.h
@@ -75,6 +75,13 @@ namespace pdaaal {
                 else //if(!_negated)
                     return _symbols.size() == n;
             }
+
+            std::vector<state_t*> follow_epsilon() const {
+                std::vector<state_t*> next{_destination};
+                NFA<T>::follow_epsilon(next);
+                return next;
+            }
+
         };
         
         struct state_t {
@@ -184,6 +191,12 @@ namespace pdaaal {
             (*this) = other;
         }
 
+        [[nodiscard]] bool empty_accept() const {
+            assert(std::is_sorted(_initial.begin(), _initial.end()));
+            // Also assume that follow_epsilon(_initial) has been executed (e.g. in compile()).
+            return std::any_of(_initial.begin(), _initial.end(), [](const state_t* s){ return s->accepting; });
+        }
+
         template<typename C>
         static void follow_epsilon(std::vector<C>& states)
         {
@@ -198,7 +211,7 @@ namespace pdaaal {
                     {
                         auto lb = std::lower_bound(states.begin(), states.end(), e._destination);
                         if(lb == std::end(states) || *lb != e._destination)
-                        {
+                        {   // FIXME: Vector.insert is usually slow for large vectors.
                             states.insert(lb, e._destination);
                             waiting.push_back(e._destination);
                         }
@@ -386,7 +399,7 @@ namespace pdaaal {
 
         const std::vector<state_t*>& initial() { return _initial; }
         const std::vector<state_t*>& accepting() { return _accepting; }
-        const std::vector<std::unique_ptr<state_t>> states() { return _states; }
+        const std::vector<std::unique_ptr<state_t>>& states() { return _states; }
         
     private:
         const static std::vector<state_t*> empty;

--- a/src/pdaaal/NewPDAFactory.h
+++ b/src/pdaaal/NewPDAFactory.h
@@ -48,8 +48,8 @@ namespace pdaaal {
     public:
         using rule_t = typename Temp_PDA::rule_t;
 
-        NewPDAFactory(NFA<T>&& initial_headers, NFA<T>&& final_headers, std::unordered_set<T>&& all_labels)
-        : _initial_headers(std::move(initial_headers)), _final_headers(std::move(final_headers)), _all_labels(std::move(all_labels)) {
+        NewPDAFactory(std::unordered_set<T>&& all_labels, NFA<T>&& initial_headers, NFA<T>&& final_headers)
+        : _all_labels(std::move(all_labels)), _initial_headers(std::move(initial_headers)), _final_headers(std::move(final_headers)) {
             _initial_headers.compile();
             _final_headers.compile();
         };
@@ -90,9 +90,10 @@ namespace pdaaal {
         virtual bool accepting(size_t) = 0;
         virtual std::vector<rule_t> rules(size_t) = 0;
 
+        std::unordered_set<T> _all_labels;
+
     private:
         NFA<T> _initial_headers, _final_headers;
-        std::unordered_set<T> _all_labels;
         std::vector<size_t> accepting_states;
     };
 

--- a/src/pdaaal/NewPDAFactory.h
+++ b/src/pdaaal/NewPDAFactory.h
@@ -57,6 +57,7 @@ namespace pdaaal {
             return SolverInstance<T,W,C,A>{Result_PDA{std::move(temp_pda)}, initial_headers, initial(), final_headers, accepting_states};
         }
 
+    private:
         void build_pda(Temp_PDA& pda) {
             // Build up PDA by searching through reachable states from initial states.
             // Derived class must define initial states, successor function (rules), and accepting state predicate.

--- a/src/pdaaal/NewPDAFactory.h
+++ b/src/pdaaal/NewPDAFactory.h
@@ -1,0 +1,101 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *  Copyright Morten K. Schou
+ */
+
+/*
+ * File:   NewPDAFactory.h
+ * Author: Morten K. Schou <morten@h-schou.dk>
+ *
+ * Created on 23-11-2020.
+ */
+
+#ifndef PDAAAL_NEWPDAFACTORY_H
+#define PDAAAL_NEWPDAFACTORY_H
+
+#include <string>
+#include <sstream>
+#include <vector>
+#include <ostream>
+#include <unordered_set>
+
+#include "NFA.h"
+#include "TypedPDA.h"
+#include "PAutomaton.h"
+#include "SolverInstance.h"
+
+namespace pdaaal {
+
+    template<typename T, typename W = void, typename C = std::less<W>, typename A = add<W>>
+    class NewPDAFactory {
+    private:
+        using Temp_PDA = TypedPDA<T,W,C,fut::type::hash>;
+        using Result_PDA = TypedPDA<T,W,C,fut::type::vector>;
+    public:
+        using rule_t = typename Temp_PDA::rule_t;
+
+        NewPDAFactory(NFA<T>&& initial_headers, NFA<T>&& final_headers, std::unordered_set<T>&& all_labels)
+        : _initial_headers(std::move(initial_headers)), _final_headers(std::move(final_headers)), _all_labels(std::move(all_labels)) {
+            _initial_headers.compile();
+            _final_headers.compile();
+        };
+
+        SolverInstance<T,W,C,A> compile() {
+            Temp_PDA temp_pda(_all_labels);
+            build_pda(temp_pda);
+            return SolverInstance<T,W,C,A>{Result_PDA{std::move(temp_pda)}, _initial_headers, initial(), _final_headers, accepting_states};
+        }
+
+        void build_pda(Temp_PDA& pda) {
+            // Build up PDA by searching through reachable states from initial states.
+            // Derived class must define initial states, successor function (rules), and accepting state predicate.
+            std::vector<size_t> waiting = initial();
+            std::unordered_set<size_t> seen(waiting.begin(), waiting.end());
+            while (!waiting.empty()) {
+                auto from = waiting.back();
+                waiting.pop_back();
+                if (accepting(from)) {
+                    accepting_states.push_back(from);
+                }
+                for (const auto &r : rules(from)) {
+                    assert(_all_labels.count(r._pre) == 1);
+                    assert(from == r._from);
+
+                    pda.add_rule(r);
+
+                    if (seen.emplace(r._to).second) {
+                        waiting.push_back(r._to);
+                    }
+                }
+            }
+            std::sort(accepting_states.begin(), accepting_states.end());
+        }
+
+    protected:
+        virtual const std::vector<size_t>& initial() = 0;
+        virtual bool accepting(size_t) = 0;
+        virtual std::vector<rule_t> rules(size_t) = 0;
+
+    private:
+        NFA<T> _initial_headers, _final_headers;
+        std::unordered_set<T> _all_labels;
+        std::vector<size_t> accepting_states;
+    };
+
+}
+
+#endif //PDAAAL_NEWPDAFACTORY_H

--- a/src/pdaaal/NewPDAFactory.h
+++ b/src/pdaaal/NewPDAFactory.h
@@ -48,16 +48,13 @@ namespace pdaaal {
     public:
         using rule_t = typename Temp_PDA::rule_t;
 
-        NewPDAFactory(std::unordered_set<T>&& all_labels, NFA<T>&& initial_headers, NFA<T>&& final_headers)
-        : _all_labels(std::move(all_labels)), _initial_headers(std::move(initial_headers)), _final_headers(std::move(final_headers)) {
-            _initial_headers.compile();
-            _final_headers.compile();
-        };
+        explicit NewPDAFactory(std::unordered_set<T>&& all_labels) : _all_labels(std::move(all_labels)) { };
 
-        SolverInstance<T,W,C,A> compile() {
+        // NFAs must be already compiled before passing them to this function.
+        SolverInstance<T,W,C,A> compile(const NFA<T>& initial_headers, const NFA<T>& final_headers) {
             Temp_PDA temp_pda(_all_labels);
             build_pda(temp_pda);
-            return SolverInstance<T,W,C,A>{Result_PDA{std::move(temp_pda)}, _initial_headers, initial(), _final_headers, accepting_states};
+            return SolverInstance<T,W,C,A>{Result_PDA{std::move(temp_pda)}, initial_headers, initial(), final_headers, accepting_states};
         }
 
         void build_pda(Temp_PDA& pda) {
@@ -93,7 +90,6 @@ namespace pdaaal {
         std::unordered_set<T> _all_labels;
 
     private:
-        NFA<T> _initial_headers, _final_headers;
         std::vector<size_t> accepting_states;
     };
 

--- a/src/pdaaal/PAutomaton.h
+++ b/src/pdaaal/PAutomaton.h
@@ -351,7 +351,7 @@ namespace pdaaal {
                         if (less(*lb, current)) {
                             *lb = current;
                         } else {
-                            break;
+                            continue;
                         }
                     } else {
                         lb = visited.insert(lb, current);

--- a/src/pdaaal/PAutomaton.h
+++ b/src/pdaaal/PAutomaton.h
@@ -158,7 +158,7 @@ namespace pdaaal {
                 if (it != nfastate_to_id.end()) {
                     n_id = it->second;
                 } else {
-                    n_id = add_state(false, n->accepting);
+                    n_id = add_state(false, n->_accepting);
                     nfastate_to_id.emplace(n, n_id);
                     waiting.emplace_back(n, n_id);
                 }

--- a/src/pdaaal/PAutomaton.h
+++ b/src/pdaaal/PAutomaton.h
@@ -387,7 +387,7 @@ namespace pdaaal {
                     auto current_state = current.first;
                     auto stack_index = current.second;
                     path[stack_index] = current_state;
-                    for (auto &[to,labels] : _states[current_state]->_edges) {
+                    for (const auto &[to,labels] : _states[current_state]->_edges) {
                         if (labels.contains(stack[stack_index])) {
                             if (stack_index + 1 < stack.size()) {
                                 search_stack.emplace(to, stack_index + 1);
@@ -413,6 +413,10 @@ namespace pdaaal {
         }
 
         [[nodiscard]] size_t number_of_labels() const { return _pda.number_of_labels(); }
+
+        [[nodiscard]] bool has_accepting_state() const {
+            return !_accepting.empty();
+        };
 
         size_t add_state(bool initial, bool accepting) {
             auto id = next_state_id();

--- a/src/pdaaal/PDA.h
+++ b/src/pdaaal/PDA.h
@@ -89,7 +89,7 @@ namespace pdaaal {
 
 namespace pdaaal::details {
     // Implementation details of PDA structure. Should not be accessed by user.
-    // PDAFactory defines rule_t to be used by users.
+    // TypedPDA defines a rule_t to be used by users.
 
     // Define rules with and without weights.
     template<typename W, typename C, typename = void>

--- a/src/pdaaal/PDAFactory.h
+++ b/src/pdaaal/PDAFactory.h
@@ -214,12 +214,11 @@ namespace pdaaal {
                 }
                 for (auto &r : rules(top)) {
                     // translate rules into PDA rules
-                    std::vector<T> pre{r._pre};
                     assert(_all_labels.count(r._pre) == 1);
                     if constexpr (is_weighted<W>) {
-                        result.add_rule(top, r._dest, r._op, r._op_label, false, pre, r._weight);
+                        result.add_rule(top, r._dest, r._op, r._op_label, r._pre, r._weight);
                     } else {
-                        result.add_rule(top, r._dest, r._op, r._op_label, false, pre);
+                        result.add_rule(top, r._dest, r._op, r._op_label, r._pre);
                     }
                     if (pdaseen.count(r._dest) == 0) {
                         pdaseen.insert(r._dest);

--- a/src/pdaaal/Solver.h
+++ b/src/pdaaal/Solver.h
@@ -733,10 +733,10 @@ namespace pdaaal {
                             edges.emplace_back(trace_label->_state, trace_label->_label, to);
                             break;
                         case PUSH:
-                            auto [from, label, to] = edges.back();
+                            auto [from2, label2, to2] = edges.back();
                             edges.pop_back();
-                            auto trace_label2 = automaton.get_trace_label(from, label, to);
-                            edges.emplace_back(trace_label2->_state, trace_label2->_label, to);
+                            auto trace_label2 = automaton.get_trace_label(from2, label2, to2);
+                            edges.emplace_back(trace_label2->_state, trace_label2->_label, to2);
                             break;
                     }
                     trace.push_back(decode_edges(edges));

--- a/src/pdaaal/Solver.h
+++ b/src/pdaaal/Solver.h
@@ -692,14 +692,10 @@ namespace pdaaal {
             std::vector<tracestate_t> trace;
             trace.push_back(decode_edges(edges));
             while (true) {
-                auto &edge = edges.back();
+                auto [from, label, to] = edges.back();
                 edges.pop_back();
-                const trace_t *trace_label = automaton.get_trace_label(edge);
+                const trace_t *trace_label = automaton.get_trace_label(from, label, to);
                 if (trace_label == nullptr) break;
-
-                auto from = std::get<0>(edge);
-                auto label = std::get<1>(edge);
-                auto to = std::get<2>(edge);
 
                 if (trace_label->is_pre_trace()) {
                     // pre* trace
@@ -737,10 +733,10 @@ namespace pdaaal {
                             edges.emplace_back(trace_label->_state, trace_label->_label, to);
                             break;
                         case PUSH:
-                            auto &edge2 = edges.back();
+                            auto [from, label, to] = edges.back();
                             edges.pop_back();
-                            auto trace_label2 = automaton.get_trace_label(edge2);
-                            edges.emplace_back(trace_label2->_state, trace_label2->_label, std::get<2>(edge2));
+                            auto trace_label2 = automaton.get_trace_label(from, label, to);
+                            edges.emplace_back(trace_label2->_state, trace_label2->_label, to);
                             break;
                     }
                     trace.push_back(decode_edges(edges));

--- a/src/pdaaal/Solver.h
+++ b/src/pdaaal/Solver.h
@@ -233,7 +233,7 @@ namespace pdaaal {
         template <Trace_Type trace_type = Trace_Type::Any, typename T, typename W, typename C, typename A>
         static bool post_star_accepts(SolverInstance<T,W,C,A>& instance) {
             instance.initialize_product();
-            return post_star<trace_type,W,C,A,true>(instance.initial_automaton(), [&instance](size_t from, uint32_t label, size_t to, trace_ptr<W> trace) -> bool {
+            return post_star<trace_type,W,C,A,true>(instance.automaton(), [&instance](size_t from, uint32_t label, size_t to, trace_ptr<W> trace) -> bool {
                 return instance.add_edge_product(from, label, to, trace);
             });
         }

--- a/src/pdaaal/Solver.h
+++ b/src/pdaaal/Solver.h
@@ -178,7 +178,7 @@ namespace pdaaal {
                 if (t._from >= n_pda_states) { continue; }
                 for (auto pre_state : pda_states[t._from]._pre_states) {
                     const auto &rules = pda_states[pre_state]._rules;
-                    auto lb = rules.lower_bound(rule_t<W,C>{t._from});
+                    auto lb = rules.lower_bound(details::rule_t<W,C>{t._from});
                     while (lb != rules.end() && lb->first._to == t._from) {
                         const auto &[rule, labels] = *lb;
                         size_t rule_id = lb - rules.begin();

--- a/src/pdaaal/SolverInstance.h
+++ b/src/pdaaal/SolverInstance.h
@@ -234,7 +234,7 @@ namespace pdaaal {
                     }
                 }
             }
-            return false;
+            return _product.has_accepting_state();
         }
 
         template<typename Elem>

--- a/src/pdaaal/SolverInstance.h
+++ b/src/pdaaal/SolverInstance.h
@@ -56,11 +56,14 @@ namespace pdaaal {
             const automaton_t& initial = _swap_initial_final ? _final : _initial;
             const automaton_t& final = _swap_initial_final ? _initial : _final;
 
-            if (from >= _id_fast_lookup.size()) { // Avoid out-of-bounds.
-                return false; // From is not yet reachable.
+            std::vector<std::pair<size_t,size_t>> from_states;
+            if (from < _id_fast_lookup.size()) { // Avoid out-of-bounds.
+                from_states = _id_fast_lookup[from]; // Copy here, since loop-body might alter _id_fast_lookup[from].
+            }
+            if (from < _pda_size) {
+                from_states.emplace_back(from, from); // Initial states are not stored in _id_fast_lookup.
             }
             std::vector<size_t> waiting;
-            auto from_states = _id_fast_lookup[from]; // Copy here, since loop-body might alter _id_fast_lookup[from].
             for (auto [final_from, product_from] : from_states) { // Iterate through reachable 'from-states'.
                 for (const auto& [final_to,final_labels] : final.states()[final_from]->_edges) {
                     if (final_labels.contains(label)) {
@@ -211,7 +214,7 @@ namespace pdaaal {
     private:
 
         // Returns whether an accepting state in the product automaton was reached.
-        bool construct_reachable(std::vector<size_t> waiting, const automaton_t& initial, const automaton_t& final) {
+        bool construct_reachable(std::vector<size_t>& waiting, const automaton_t& initial, const automaton_t& final) {
             while (!waiting.empty()) {
                 size_t top = waiting.back();
                 waiting.pop_back();

--- a/src/pdaaal/SolverInstance.h
+++ b/src/pdaaal/SolverInstance.h
@@ -144,11 +144,11 @@ namespace pdaaal {
                         std::vector<uint32_t> label_stack(current.stack_index);
                         const queue_elem* p = &current;
                         while (p->stack_index > 0) {
-                            path[p->stack_index] = p->state;
+                            path[p->stack_index] = get_original_ids(p->state).first;
                             label_stack[p->stack_index - 1] = p->label;
                             p = p->back_pointer;
                         }
-                        path[p->stack_index] = p->state;
+                        path[p->stack_index] = get_original_ids(p->state).first;
                         return {path, label_stack, current.weight};
                     }
 
@@ -197,10 +197,10 @@ namespace pdaaal {
                             uint32_t label = labels[0].first;
                             path.resize(stack_index + 2);
                             label_stack.resize(stack_index + 1);
-                            path[stack_index] = current;
+                            path[stack_index] = get_original_ids(current).first;
                             label_stack[stack_index] = label;
                             if (_product.states()[to]->_accepting) {
-                                path[stack_index + 1] = to;
+                                path[stack_index + 1] = get_original_ids(to).first;
                                 return {path, label_stack};
                             }
                             waiting.emplace_back(to, stack_index + 1);

--- a/src/pdaaal/SolverInstance.h
+++ b/src/pdaaal/SolverInstance.h
@@ -1,0 +1,286 @@
+/* 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *  Copyright Morten K. Schou
+ */
+
+/* 
+ * File:   SolverInstance.h
+ * Author: Morten K. Schou <morten@h-schou.dk>
+ *
+ * Created on 27-11-2020.
+ */
+
+#ifndef PDAAAL_SOLVERINSTANCE_H
+#define PDAAAL_SOLVERINSTANCE_H
+
+#include "PAutomaton.h"
+
+namespace pdaaal {
+
+    template <typename T, typename W = void, typename C = std::less<W>, typename A = add<W>>
+    class SolverInstance {
+        using pda_t = TypedPDA<T,W,C,fut::type::vector>;
+        using automaton_t = PAutomaton<W,C,A>;
+        using state_t = typename automaton_t::state_t;
+    public:
+        SolverInstance(pda_t&& pda, const NFA<T>& initial_nfa, const std::vector<size_t>& initial_states,
+                                    const NFA<T>& final_nfa,   const std::vector<size_t>& final_states)
+        : _pda(std::move(pda)), _pda_size(_pda.states().size()), _initial(_pda, initial_nfa, initial_states),
+          _final(_pda, final_nfa, final_states), _product(_pda, intersect_vector(initial_states, final_states)) { };
+
+        // Returns whether an accepting state in the product automaton was reached.
+        bool initialize_product() {
+            std::vector<size_t> ids(_product.states().size());
+            std::iota (ids.begin(), ids.end(), 0); // Fill with 0,1,...,size-1;
+            return construct_reachable(ids,
+                                       _swap_initial_final ? _final : _initial,
+                                       _swap_initial_final ? _initial : _final);
+        }
+
+        // Returns whether an accepting state in the product automaton was reached.
+        bool add_edge_product(size_t from, uint32_t label, size_t to, trace_ptr<W> trace) {
+            const automaton_t& initial = _swap_initial_final ? _final : _initial;
+            const automaton_t& final = _swap_initial_final ? _initial : _final;
+
+            if (from >= _id_fast_lookup.size()) { // Avoid out-of-bounds.
+                return false; // From is not yet reachable.
+            }
+            std::vector<size_t> waiting;
+            auto from_states = _id_fast_lookup[from]; // Copy here, since loop-body might alter _id_fast_lookup[from].
+            for (auto [final_from, product_from] : from_states) { // Iterate through reachable 'from-states'.
+                for (const auto& [final_to,final_labels] : final.states()[final_from]->edges) {
+                    if (final_labels.contains(label)) {
+                        auto [fresh, product_to] = get_product_state(initial.states()[to], final.states()[final_to]);
+                        _product.add_edge(product_from, product_to, label, trace);
+                        if (_product.has_accepting_state()) {
+                            return true; // Early termination
+                        }
+                        if (fresh) {
+                            waiting.push_back(product_to); // If the 'to-state' is new (was not previously reachable), we need to continue constructing from there.
+                        }
+                    }
+                }
+            }
+            return construct_reachable(waiting);
+        }
+
+        automaton_t& automaton() {
+            return _swap_initial_final ? _final : _initial;
+        }
+        const pda_t& pda() {
+            return _pda;
+        }
+
+        void enable_pre_star() {
+            _swap_initial_final = true;
+        }
+
+        template<Trace_Type trace_type = Trace_Type::Any>
+        [[nodiscard]] typename std::conditional_t<trace_type == Trace_Type::Shortest && is_weighted<W>,
+                std::tuple<std::vector<size_t>, std::vector<uint32_t>, W>,
+                std::tuple<std::vector<size_t>, std::vector<uint32_t>>>
+        find_path() {
+            if constexpr (trace_type == Trace_Type::Shortest && is_weighted<W>) { // TODO: Consider unweighted shortest path.
+                // Dijkstra.
+                struct queue_elem {
+                    W weight;
+                    size_t state;
+                    uint32_t label;
+                    size_t stack_index;
+                    const queue_elem *back_pointer;
+                    queue_elem(W weight, size_t state, uint32_t label, size_t stack_index, const queue_elem *back_pointer = nullptr)
+                            : weight(weight), state(state), label(label), stack_index(stack_index), back_pointer(back_pointer) {};
+
+                    bool operator<(const queue_elem &other) const {
+                        if (state != other.state) {
+                            return state < other.state;
+                        }
+                        return label < other.label;
+                    }
+                    bool operator==(const queue_elem &other) const {
+                        return state == other.state && label == other.label;
+                    }
+                    bool operator!=(const queue_elem &other) const {
+                        return !(*this == other);
+                    }
+                };
+                struct queue_elem_comp {
+                    bool operator()(const queue_elem &lhs, const queue_elem &rhs){
+                        C less;
+                        return less(rhs.weight, lhs.weight); // Used in a max-heap, so swap arguments to make it a min-heap.
+                    }
+                };
+                queue_elem_comp less;
+                A add;
+                std::priority_queue<queue_elem, std::vector<queue_elem>, queue_elem_comp> search_queue;
+                std::vector<queue_elem> visited;
+                std::vector<std::unique_ptr<queue_elem>> pointers;
+                for (size_t i = 0; i < _pda_size; ++i) { // Iterate over _product._initial ([i]->_id)
+                    search_queue.emplace(zero<W>()(), i, std::numeric_limits<uint32_t>::max(), 0); // No label going into initial state.
+                }
+                while(!search_queue.empty()) {
+                    auto current = search_queue.top();
+                    search_queue.pop();
+
+                    if (_product.states()[current.state]->_accepting) {
+                        std::vector<size_t> path(current.stack_index + 1);
+                        std::vector<uint32_t> label_stack(current.stack_index);
+                        auto p = &current;
+                        while (p->stack_index > 0) {
+                            path[p->stack_index] = p->state;
+                            label_stack[p->stack_index - 1] = p->label;
+                            p = p->back_pointer;
+                        }
+                        path[p->stack_index] = p->state;
+                        return {path, label_stack, current.weight};
+                    }
+
+                    auto lb = std::lower_bound(visited.begin(), visited.end(), current);
+                    if (lb != std::end(visited) && *lb == current) {
+                        if (less(*lb, current)) {
+                            *lb = current;
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        lb = visited.insert(lb, current); // TODO: Consider using std::unordered_map instead...
+                    }
+                    auto u_pointer = std::make_unique<queue_elem>(*lb);
+                    auto pointer = u_pointer.get();
+                    pointers.push_back(std::move(u_pointer));
+                    for (const auto &[to,labels] : _product.states()[current.state]->_edges) {
+                        if (!labels.empty()) {
+                            auto label = labels[0].first;
+                            search_queue.emplace(add(current.weight, label->second), to, label, current.stack_index + 1, pointer);
+                        }
+                    }
+                }
+                return {std::vector<size_t>(), std::vector<uint32_t>(), max<W>()()};
+            } else {
+                // DFS search.
+                std::vector<size_t> path;
+                std::vector<uint32_t> label_stack;
+
+                std::vector<std::pair<size_t,size_t>> waiting; // state_id, stack_index
+                waiting.reserve(_pda_size);
+                for (size_t i = 0; i < _pda_size; ++i) {
+                    if (_product.states()[i]->_accepting) { // Initial accepting state
+                        path.push_back(i);
+                        return {path, label_stack};
+                    }
+                    waiting.emplace_back(i,0); // Add all initial states in _product.
+                }
+                std::unordered_set<size_t> seen;
+
+                while (!waiting.empty()) {
+                    auto [current, stack_index] = waiting.back();
+                    waiting.pop_back();
+                    for (const auto &[to,labels] : _product.states()[current]->_edges) {
+                        if (!labels.empty() && seen.emplace(to).second) {
+                            uint32_t label = labels[0].first;
+                            path.resize(stack_index + 2);
+                            label_stack.resize(stack_index + 1);
+                            path[stack_index] = current;
+                            label_stack[stack_index] = label;
+                            if (_product.states()[to]->_accepting) {
+                                path[stack_index + 1] = to;
+                                return {path, label_stack};
+                            }
+                            waiting.emplace_back(to, stack_index + 1);
+                        }
+                    }
+                }
+                return {std::vector<size_t>(), std::vector<uint32_t>()};
+            }
+        }
+
+    private:
+
+        // Returns whether an accepting state in the product automaton was reached.
+        bool construct_reachable(std::vector<size_t> waiting, const automaton_t& initial, const automaton_t& final) {
+            while (!waiting.empty()) {
+                size_t top = waiting.back();
+                waiting.pop_back();
+                auto [i_from,f_from] = get_original_ids(top);
+                for (const auto& [i_to,i_labels] : initial.states()[i_from]->_edges) {
+                    for (const auto& [f_to,f_labels] : final.states()[f_from]->edges) {
+                        auto labels = intersect_vector(i_labels, f_labels);
+                        if (!labels.empty()) {
+                            auto [fresh, to_id] = get_product_state(initial.states()[i_to], final.states()[f_to]);
+                            for (const auto & [label, trace] : labels) {
+                                _product.add_edge(top, to_id, label, trace);
+                            }
+                            if (_product.has_accepting_state()) {
+                                return true; // Early termination
+                            }
+                            if (fresh) {
+                                waiting.push_back(to_id);
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        template<typename Elem>
+        static std::vector<Elem> intersect_vector(const std::vector<Elem>& v1, const std::vector<Elem>& v2) {
+            assert(std::is_sorted(v1.begin(), v1.end()));
+            assert(std::is_sorted(v2.begin(), v2.end()));
+            std::vector<Elem> result;
+            std::set_intersection(v1.begin(), v1.end(), v2.begin(), v2.end(), std::back_inserter(result));
+            return result;
+        }
+
+        std::pair<size_t,size_t> get_original_ids(size_t id) {
+            if (id < _pda_size) {
+                return {id,id};
+            }
+            std::pair<size_t,size_t> res;
+            _id_map.unpack(id - _pda_size, &res);
+            return res;
+        }
+        std::pair<bool,size_t> get_product_state(state_t a, state_t b) {
+            if (a._id == b._id && a._id < _pda_size) {
+                return {false,a._id};
+            }
+            auto [fresh, id] = _id_map.insert(std::make_pair(a._id, b._id));
+            if (fresh) {
+                size_t state_id = _product.add_state(false, a._accepting && b._accepting);
+                assert(state_id == id + _pda_size);
+                if (a._id >= _id_fast_lookup.size()) {
+                    _id_fast_lookup.resize(a._id + 1);
+                }
+                _id_fast_lookup[a._id].emplace_back(b._id, state_id);
+                return {true, state_id};
+            } else {
+                return {false ,id + _pda_size};
+            }
+        }
+
+        const pda_t _pda;
+        const size_t _pda_size;
+        automaton_t _initial;
+        automaton_t _final;
+        automaton_t _product;
+        bool _swap_initial_final = false;
+        ptrie::set_stable<std::pair<size_t,size_t>> _id_map;
+        std::vector<std::vector<std::pair<size_t,size_t>>> _id_fast_lookup;
+    };
+}
+
+#endif //PDAAAL_SOLVERINSTANCE_H

--- a/src/pdaaal/SolverInstance.h
+++ b/src/pdaaal/SolverInstance.h
@@ -28,6 +28,7 @@
 #define PDAAAL_SOLVERINSTANCE_H
 
 #include "PAutomaton.h"
+#include <limits>
 
 namespace pdaaal {
 
@@ -178,32 +179,35 @@ namespace pdaaal {
                 std::vector<size_t> path;
                 std::vector<uint32_t> label_stack;
 
-                std::vector<std::pair<size_t,size_t>> waiting; // state_id, stack_index
+                std::vector<std::tuple<size_t,size_t,uint32_t>> waiting; // state_id, stack_index, last_label (if stack_index > 0)
                 waiting.reserve(_pda_size);
                 for (size_t i = 0; i < _pda_size; ++i) {
                     if (_product.states()[i]->_accepting) { // Initial accepting state
                         path.push_back(i);
                         return {path, label_stack};
                     }
-                    waiting.emplace_back(i,0); // Add all initial states in _product.
+                    waiting.emplace_back(i, 0, std::numeric_limits<uint32_t>::max()); // Add all initial states in _product.
                 }
                 std::unordered_set<size_t> seen;
 
                 while (!waiting.empty()) {
-                    auto [current, stack_index] = waiting.back();
+                    auto [current, stack_index, last_label] = waiting.back();
                     waiting.pop_back();
+                    path.resize(stack_index + 2);
+                    label_stack.resize(stack_index + 1);
+                    path[stack_index] = get_original_ids(current).first;
+                    if (stack_index > 0) {
+                        label_stack[stack_index-1] = last_label;
+                    }
                     for (const auto &[to,labels] : _product.states()[current]->_edges) {
                         if (!labels.empty() && seen.emplace(to).second) {
                             uint32_t label = labels[0].first;
-                            path.resize(stack_index + 2);
-                            label_stack.resize(stack_index + 1);
-                            path[stack_index] = get_original_ids(current).first;
-                            label_stack[stack_index] = label;
                             if (_product.states()[to]->_accepting) {
                                 path[stack_index + 1] = get_original_ids(to).first;
+                                label_stack[stack_index] = label;
                                 return {path, label_stack};
                             }
-                            waiting.emplace_back(to, stack_index + 1);
+                            waiting.emplace_back(to, stack_index + 1, label);
                         }
                     }
                 }

--- a/src/pdaaal/TypedPDA.h
+++ b/src/pdaaal/TypedPDA.h
@@ -170,15 +170,15 @@ namespace pdaaal {
         }
 
         template<typename WT, typename = std::enable_if_t<!is_weighted<WT>>>
-        void add_rule_(size_t from, size_t to, op_t op, T label, bool negated, T pre) {
+        void add_rule_(size_t from, size_t to, op_t op, T label, T pre) {
             std::vector<T> _pre{pre};
-            add_rule(from, to, op, label, negated, _pre);
+            add_rule(from, to, op, label, false, _pre);
         }
 
         template<typename WT, typename = std::enable_if_t<is_weighted<WT>>>
-        void add_rule_(size_t from, size_t to, op_t op, T label, bool negated, T pre, WT weight = zero<WT>()()) {
+        void add_rule_(size_t from, size_t to, op_t op, T label, T pre, WT weight = zero<WT>()()) {
             std::vector<T> _pre{pre};
-            add_rule(from, to, op, label, negated, _pre, weight);
+            add_rule(from, to, op, label, false, _pre, weight);
         }
 
         ptrie::set_stable<T> _label_map;

--- a/src/pdaaal/TypedPDA.h
+++ b/src/pdaaal/TypedPDA.h
@@ -42,6 +42,9 @@ namespace pdaaal {
 
     template<typename T, typename W = void, typename C = std::less<W>, fut::type Container = fut::type::vector>
     class TypedPDA : public PDA<W, C, Container> {
+    protected:
+        using rule_t = typename PDA<W, C, Container>::rule_t;
+
     public:
         struct tracestate_t {
             size_t _pdastate = 0;
@@ -116,7 +119,7 @@ namespace pdaaal {
             return std::numeric_limits<uint32_t>::max();
         }
 
-        void add_rules_impl(size_t from, rule_t <W, C> rule, bool negated, const std::vector<T> &labels, bool negated_pre, const std::vector<T> &pre) {
+        void add_rules_impl(size_t from, rule_t rule, bool negated, const std::vector<T> &labels, bool negated_pre, const std::vector<T> &pre) {
             auto tpre = encode_pre(pre);
             if (negated) {
                 size_t last = 0;

--- a/test/PAutomaton_test.cpp
+++ b/test/PAutomaton_test.cpp
@@ -40,11 +40,11 @@ BOOST_AUTO_TEST_CASE(UnweightedPreStar)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char> pda(labels);
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A');
-    pda.add_rule(0, 0, POP, '*', false, 'B');
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B');
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C');
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A');
+    pda.add_rule(0, 1, PUSH, 'B', 'A');
+    pda.add_rule(0, 0, POP, '*', 'B');
+    pda.add_rule(1, 3, SWAP, 'A', 'B');
+    pda.add_rule(2, 0, SWAP, 'B', 'C');
+    pda.add_rule(3, 2, PUSH, 'C', 'A');
 
     std::vector<char> init_stack{'A', 'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -64,11 +64,11 @@ BOOST_AUTO_TEST_CASE(UnweightedPostStar)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char> pda(labels);
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A');
-    pda.add_rule(0, 0, POP, '*', false, 'B');
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B');
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C');
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A');
+    pda.add_rule(0, 1, PUSH, 'B', 'A');
+    pda.add_rule(0, 0, POP, '*', 'B');
+    pda.add_rule(1, 3, SWAP, 'A', 'B');
+    pda.add_rule(2, 0, SWAP, 'B', 'C');
+    pda.add_rule(3, 2, PUSH, 'C', 'A');
 
     std::vector<char> init_stack{'A', 'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -91,11 +91,11 @@ BOOST_AUTO_TEST_CASE(UnweightedPostStarPath)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char> pda(labels);
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A');
-    pda.add_rule(0, 0, POP, '*', false, 'B');
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B');
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C');
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A');
+    pda.add_rule(0, 1, PUSH, 'B', 'A');
+    pda.add_rule(0, 0, POP, '*', 'B');
+    pda.add_rule(1, 3, SWAP, 'A', 'B');
+    pda.add_rule(2, 0, SWAP, 'B', 'C');
+    pda.add_rule(3, 2, PUSH, 'C', 'A');
 
     std::vector<char> init_stack{'A', 'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -116,11 +116,11 @@ BOOST_AUTO_TEST_CASE(WeightedPreStar)
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char, std::vector<int>> pda(labels);
     std::vector<int> w{1};
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A', w);
-    pda.add_rule(0, 0, POP , '*', false, 'B', w);
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B', w);
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C', w);
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A', w);
+    pda.add_rule(0, 1, PUSH, 'B', 'A', w);
+    pda.add_rule(0, 0, POP , '*', 'B', w);
+    pda.add_rule(1, 3, SWAP, 'A', 'B', w);
+    pda.add_rule(2, 0, SWAP, 'B', 'C', w);
+    pda.add_rule(3, 2, PUSH, 'C', 'A', w);
 
     std::vector<char> init_stack{'A', 'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -141,11 +141,11 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar)
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char, std::array<double, 3>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A', w);
-    pda.add_rule(0, 0, POP , '*', false, 'B', w);
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B', w);
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C', w);
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A', w);
+    pda.add_rule(0, 1, PUSH, 'B', 'A', w);
+    pda.add_rule(0, 0, POP , '*', 'B', w);
+    pda.add_rule(1, 3, SWAP, 'A', 'B', w);
+    pda.add_rule(2, 0, SWAP, 'B', 'C', w);
+    pda.add_rule(3, 2, PUSH, 'C', 'A', w);
 
     std::vector<char> init_stack{'A', 'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -164,13 +164,13 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar2)
     std::unordered_set<char> labels{'A', 'B'};
     TypedPDA<char, int> pda(labels);
 
-    pda.add_rule(1, 2, POP, '*', false, 'A', 1);
-    pda.add_rule(1, 3, PUSH , 'B', false, 'A', 3);
-    pda.add_rule(1, 3, SWAP, 'A',  false, 'B', 2);
-    pda.add_rule(2, 1, POP, '*',  false, 'B', 4);
+    pda.add_rule(1, 2, POP, '*', 'A', 1);
+    pda.add_rule(1, 3, PUSH , 'B', 'A', 3);
+    pda.add_rule(1, 3, SWAP, 'A',  'B', 2);
+    pda.add_rule(2, 1, POP, '*',  'B', 4);
     std::vector<char> pre{'A', 'B'};
     pda.add_rule(2, 2, PUSH, 'B', false, pre, 5);
-    pda.add_rule(3, 1, POP, '*', false, 'B', 1);
+    pda.add_rule(3, 1, POP, '*', 'B', 1);
 
     std::vector<char> init_stack{'A', 'B', 'A'};
     PAutomaton automaton(pda, 1, pda.encode_pre(init_stack));
@@ -187,10 +187,10 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar3)
     TypedPDA<char, int> pda(labels);
     std::vector<char> pre{'A'};
 
-    pda.add_rule(1, 2, PUSH, 'A', false, 'A', 16);
-    pda.add_rule(1, 3, PUSH , 'A', false, 'A', 1);
-    pda.add_rule(3, 3, PUSH , 'A', false, 'A', 2);
-    pda.add_rule(3, 2, POP , 'A', false, 'A', 1);
+    pda.add_rule(1, 2, PUSH, 'A', 'A', 16);
+    pda.add_rule(1, 3, PUSH , 'A', 'A', 1);
+    pda.add_rule(3, 3, PUSH , 'A', 'A', 2);
+    pda.add_rule(3, 2, POP , 'A', 'A', 1);
 
     std::vector<char> init_stack{'A'};
     PAutomaton automaton(pda, 1, pda.encode_pre(init_stack));
@@ -206,11 +206,11 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar4)
     std::unordered_set<char> labels{'A'};
     TypedPDA<char, int> pda(labels);
 
-    pda.add_rule(0, 3, PUSH, 'A', false, 'A', 4);
-    pda.add_rule(0, 1, PUSH , 'A', false, 'A', 1);
-    pda.add_rule(3, 1, PUSH , 'A', false, 'A', 8);
-    pda.add_rule(1, 2, POP , 'A', false, 'A', 2);
-    pda.add_rule(2, 4, POP , 'A', false, 'A', 16);
+    pda.add_rule(0, 3, PUSH, 'A', 'A', 4);
+    pda.add_rule(0, 1, PUSH , 'A', 'A', 1);
+    pda.add_rule(3, 1, PUSH , 'A', 'A', 8);
+    pda.add_rule(1, 2, POP , 'A', 'A', 2);
+    pda.add_rule(2, 4, POP , 'A', 'A', 16);
 
     std::vector<char> init_stack{'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -226,11 +226,11 @@ BOOST_AUTO_TEST_CASE(WeightedPostStarResult)
     std::unordered_set<char> labels{'A'};
     TypedPDA<char, int> pda(labels);
 
-    pda.add_rule(0, 3, PUSH, 'A', false, 'A', 4);
-    pda.add_rule(0, 1, PUSH , 'A', false, 'A', 1);
-    pda.add_rule(3, 1, PUSH , 'A', false, 'A', 8);
-    pda.add_rule(1, 2, POP , 'A', false, 'A', 2);
-    pda.add_rule(2, 4, POP , 'A', false, 'A', 16);
+    pda.add_rule(0, 3, PUSH, 'A', 'A', 4);
+    pda.add_rule(0, 1, PUSH , 'A', 'A', 1);
+    pda.add_rule(3, 1, PUSH , 'A', 'A', 8);
+    pda.add_rule(1, 2, POP , 'A', 'A', 2);
+    pda.add_rule(2, 4, POP , 'A', 'A', 16);
 
     std::vector<char> init_stack{'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -254,11 +254,11 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar4EarlyTermination)
     std::unordered_set<char> labels{'A'};
     TypedPDA<char, int> pda(labels);
 
-    pda.add_rule(0, 3, PUSH, 'A', false, 'A', 4);
-    pda.add_rule(0, 1, PUSH , 'A', false, 'A', 1);
-    pda.add_rule(3, 1, PUSH , 'A', false, 'A', 8);
-    pda.add_rule(1, 2, POP , 'A', false, 'A', 2);
-    pda.add_rule(2, 4, POP , 'A', false, 'A', 16);
+    pda.add_rule(0, 3, PUSH, 'A', 'A', 4);
+    pda.add_rule(0, 1, PUSH , 'A', 'A', 1);
+    pda.add_rule(3, 1, PUSH , 'A', 'A', 8);
+    pda.add_rule(1, 2, POP , 'A', 'A', 2);
+    pda.add_rule(2, 4, POP , 'A', 'A', 16);
 
     std::vector<char> init_stack{'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -280,25 +280,25 @@ TypedPDA<int,int> create_syntactic_network_broad(int network_size = 2) {
     TypedPDA<int, int> pda(labels);
 
     for (int j = 0; j < network_size; j++) {
-        pda.add_rule(start_state, 1 + start_state, PUSH, 0, false, 0, 0);
-        pda.add_rule(start_state, 1 + start_state, PUSH, 1, false, 0, 1);
-        pda.add_rule(start_state, 1 + start_state, PUSH, 2, false, 0, 1);
-        pda.add_rule(start_state, 2 + start_state, PUSH, 0, false, 2, 0);
-        pda.add_rule(start_state, 3 + start_state, POP, 0, false, 1, 1);
+        pda.add_rule(start_state, 1 + start_state, PUSH, 0, 0, 0);
+        pda.add_rule(start_state, 1 + start_state, PUSH, 1, 0, 1);
+        pda.add_rule(start_state, 1 + start_state, PUSH, 2, 0, 1);
+        pda.add_rule(start_state, 2 + start_state, PUSH, 0, 2, 0);
+        pda.add_rule(start_state, 3 + start_state, POP, 0, 1, 1);
 
-        pda.add_rule(1 + start_state, 3 + start_state, PUSH, 1, false, 2, 1);
-        pda.add_rule(1 + start_state, end_state, PUSH, 0, false, 0, 1);
-        pda.add_rule(1 + start_state, end_state, PUSH, 1, false, 1, 1);
+        pda.add_rule(1 + start_state, 3 + start_state, PUSH, 1, 2, 1);
+        pda.add_rule(1 + start_state, end_state, PUSH, 0, 0, 1);
+        pda.add_rule(1 + start_state, end_state, PUSH, 1, 1, 1);
 
         for (size_t i = 0; i < labels.size(); i++) {
-            pda.add_rule(2 + start_state, 2 + start_state, POP, 0, false, i, 5);
+            pda.add_rule(2 + start_state, 2 + start_state, POP, 0, i, 5);
         }
 
-        pda.add_rule(2 + start_state, end_state, PUSH, 0, false, 0, 1);
+        pda.add_rule(2 + start_state, end_state, PUSH, 0, 0, 1);
 
-        pda.add_rule(3 + start_state, 2 + start_state, POP, 0, false, 2, 1);
-        pda.add_rule(3 + start_state, end_state, PUSH, 2, false, 0, 1);
-        pda.add_rule(3 + start_state, end_state, PUSH, 2, false, 1, 1);
+        pda.add_rule(3 + start_state, 2 + start_state, POP, 0, 2, 1);
+        pda.add_rule(3 + start_state, end_state, PUSH, 2, 0, 1);
+        pda.add_rule(3 + start_state, end_state, PUSH, 2, 1, 1);
 
         start_state = end_state;
         end_state = end_state + states;
@@ -315,22 +315,22 @@ TypedPDA<int,int> create_syntactic_network_deep(int network_size = 2){
     int new_end_state = 6;
 
     for(int j = 0; j < network_size; j++){
-        pda.add_rule(start_state, 1+start_state, POP, 2, false, 1, 1);
+        pda.add_rule(start_state, 1+start_state, POP, 2, 1, 1);
 
-        pda.add_rule(1+start_state, end_state, SWAP, 2, false, 0, 1);
+        pda.add_rule(1+start_state, end_state, SWAP, 2, 0, 1);
 
-        pda.add_rule(end_state, 3+start_state, POP, 1, false, 2, 1);
+        pda.add_rule(end_state, 3+start_state, POP, 1, 2, 1);
 
-        pda.add_rule(3+start_state, start_state, SWAP, 1, false, 0, 1);
+        pda.add_rule(3+start_state, start_state, SWAP, 1, 0, 1);
 
         for(size_t i = 0; i < labels.size(); i++){
             for(size_t k = 0; k < labels.size(); k++) {
-                pda.add_rule(new_start_state, start_state, PUSH, i, false, k, 1);
+                pda.add_rule(new_start_state, start_state, PUSH, i, k, 1);
             }
         }
         for(size_t i = 0; i < labels.size(); i++){
             for(size_t k = 0; k < labels.size(); k++) {
-                pda.add_rule(end_state, new_end_state, PUSH, i, false, k, 1);
+                pda.add_rule(end_state, new_end_state, PUSH, i, k, 1);
             }
         }
         start_state = new_start_state;
@@ -371,9 +371,9 @@ BOOST_AUTO_TEST_CASE(WeightedPostStarVSPostUnorderedPerformance)
     TypedPDA<int, int> pda(labels);
 
     for(int i = 0; i < alphabet_size; i++){
-        pda.add_rule(0, 1, SWAP, i, false, 0, 1);
-        pda.add_rule(1, 2, SWAP, 0, false, i, i);
-        pda.add_rule(2, 3, PUSH, i, false, 0, 1);
+        pda.add_rule(0, 1, SWAP, i, 0, 1);
+        pda.add_rule(1, 2, SWAP, 0, i, i);
+        pda.add_rule(2, 3, PUSH, i, 0, 1);
     }
 
     std::vector<int> init_stack;

--- a/test/PAutomaton_test.cpp
+++ b/test/PAutomaton_test.cpp
@@ -34,6 +34,37 @@
 
 using namespace pdaaal;
 
+BOOST_AUTO_TEST_CASE(Dijkstra_Test_1)
+{
+    std::unordered_set<char> labels{'A'};
+    TypedPDA<char, int> pda(labels);
+    pda.add_rule(0, 0, POP, '*', 'A', 0);
+
+    PAutomaton automaton(pda, std::vector<size_t>());
+    auto id1 = automaton.add_state(false, false);
+    auto id2 = automaton.add_state(false, false);
+    auto id3 = automaton.add_state(false, false);
+    auto id4 = automaton.add_state(false, true);
+
+    automaton.add_edge(0, id1, 0, std::make_pair(nullptr, 1));
+    automaton.add_edge(0, id2, 0, std::make_pair(nullptr, 2));
+    automaton.add_edge(id1, id3, 0, std::make_pair(nullptr, 2));
+    automaton.add_edge(id3, id4, 0, std::make_pair(nullptr, 2));
+
+    std::vector<char> test_stack{'A', 'A', 'A'};
+    std::vector<size_t> correct_path{0,id1,id3,id4};
+    auto [path, w] = automaton.template accept_path<Trace_Type::Shortest>(0, pda.encode_pre(test_stack));
+    BOOST_CHECK_EQUAL(w, 5);
+    BOOST_CHECK_EQUAL_COLLECTIONS(path.begin(), path.end(), correct_path.begin(), correct_path.end());
+
+    automaton.add_edge(id2, id3, 0, std::make_pair(nullptr, 2));
+
+    // A bug in the implementation of Dijkstra in PAutomaton caused the following to fail. It is now fixed.
+    auto [path2, w2] = automaton.template accept_path<Trace_Type::Shortest>(0, pda.encode_pre(test_stack));
+    BOOST_CHECK_EQUAL(w2, 5);
+    BOOST_CHECK_EQUAL_COLLECTIONS(path2.begin(), path2.end(), correct_path.begin(), correct_path.end());
+}
+
 BOOST_AUTO_TEST_CASE(UnweightedPreStar)
 {
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)

--- a/test/PDAFactory_test.cpp
+++ b/test/PDAFactory_test.cpp
@@ -28,6 +28,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <pdaaal/PDAFactory.h>
+#include <pdaaal/NewPDAFactory.h>
 
 using namespace pdaaal;
 

--- a/test/PDA_test.cpp
+++ b/test/PDA_test.cpp
@@ -82,11 +82,11 @@ BOOST_AUTO_TEST_CASE(LabelsMerge)
 BOOST_AUTO_TEST_CASE(PDA_Container_Type) {
     std::unordered_set<char> labels{'A', 'B'};
     TypedPDA<char,int,std::less<int>,fut::type::hash> pda(labels);
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A');
+    pda.add_rule(0, 1, PUSH, 'B', 'A');
 
     TypedPDA<char,int> pda2(std::move(pda));
 
-    pda2.add_rule(1, 3, SWAP, 'A', false, 'B');
+    pda2.add_rule(1, 3, SWAP, 'A', 'B');
 
     BOOST_CHECK_EQUAL(true, true);
 }

--- a/test/Reducer_test.cpp
+++ b/test/Reducer_test.cpp
@@ -38,11 +38,11 @@ BOOST_AUTO_TEST_CASE(ReducerTest1) {
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char, std::array<double, 3>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A', w);
-    pda.add_rule(0, 0, POP , '*', false, 'B', w);
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B', w);
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C', w);
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A', w);
+    pda.add_rule(0, 1, PUSH, 'B', 'A', w);
+    pda.add_rule(0, 0, POP , '*', 'B', w);
+    pda.add_rule(1, 3, SWAP, 'A', 'B', w);
+    pda.add_rule(2, 0, SWAP, 'B', 'C', w);
+    pda.add_rule(3, 2, PUSH, 'C', 'A', w);
 
     auto res = Reducer::reduce(pda, 3, 3, 0);
 

--- a/test/Solver_test.cpp
+++ b/test/Solver_test.cpp
@@ -38,11 +38,11 @@ BOOST_AUTO_TEST_CASE(SolverTest1)
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char, std::array<double, 3>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A', w);
-    pda.add_rule(0, 0, POP , '*', false, 'B', w);
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B', w);
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C', w);
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A', w);
+    pda.add_rule(0, 1, PUSH, 'B', 'A', w);
+    pda.add_rule(0, 0, POP , '*', 'B', w);
+    pda.add_rule(1, 3, SWAP, 'A', 'B', w);
+    pda.add_rule(2, 0, SWAP, 'B', 'C', w);
+    pda.add_rule(3, 2, PUSH, 'C', 'A', w);
 
     std::vector<char> init_stack{'A', 'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -61,11 +61,11 @@ BOOST_AUTO_TEST_CASE(SolverTest2)
     std::unordered_set<uint32_t> labels{2,3,4};
     TypedPDA<uint32_t, std::array<double, 3>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
-    pda.add_rule(0, 1, PUSH, 3, false, 2, w);
-    pda.add_rule(0, 0, POP , '*', false, 3, w);
-    pda.add_rule(1, 3, SWAP, 2, false, 3, w);
-    pda.add_rule(2, 0, SWAP, 3, false, 4, w);
-    pda.add_rule(3, 2, PUSH, 4, false, 2, w);
+    pda.add_rule(0, 1, PUSH, 3, 2, w);
+    pda.add_rule(0, 0, POP , '*', 3, w);
+    pda.add_rule(1, 3, SWAP, 2, 3, w);
+    pda.add_rule(2, 0, SWAP, 3, 4, w);
+    pda.add_rule(3, 2, PUSH, 4, 2, w);
 
     std::vector<uint32_t> init_stack{2, 2};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -84,11 +84,11 @@ BOOST_AUTO_TEST_CASE(SolverTest3)
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char, std::array<double, 3>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A', w);
-    pda.add_rule(0, 0, POP , '*', false, 'B', w);
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B', w);
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C', w);
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A', w);
+    pda.add_rule(0, 1, PUSH, 'B', 'A', w);
+    pda.add_rule(0, 0, POP , '*', 'B', w);
+    pda.add_rule(1, 3, SWAP, 'A', 'B', w);
+    pda.add_rule(2, 0, SWAP, 'B', 'C', w);
+    pda.add_rule(3, 2, PUSH, 'C', 'A', w);
 
     std::vector<char> init_stack{'A', 'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -108,11 +108,11 @@ BOOST_AUTO_TEST_CASE(EarlyTerminationPostStar)
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char, std::array<double, 3>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A', w);
-    pda.add_rule(0, 0, POP , '*', false, 'B', w);
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B', w);
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C', w);
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A', w);
+    pda.add_rule(0, 1, PUSH, 'B', 'A', w);
+    pda.add_rule(0, 0, POP , '*', 'B', w);
+    pda.add_rule(1, 3, SWAP, 'A', 'B', w);
+    pda.add_rule(2, 0, SWAP, 'B', 'C', w);
+    pda.add_rule(3, 2, PUSH, 'C', 'A', w);
 
     std::vector<char> init_stack{'A', 'A'};
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -133,11 +133,11 @@ BOOST_AUTO_TEST_CASE(EarlyTerminationPreStar)
     std::unordered_set<char> labels{'A', 'B', 'C'};
     TypedPDA<char, std::array<double, 3>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
-    pda.add_rule(0, 1, PUSH, 'B', false, 'A', w);
-    pda.add_rule(0, 0, POP , '*', false, 'B', w);
-    pda.add_rule(1, 3, SWAP, 'A', false, 'B', w);
-    pda.add_rule(2, 0, SWAP, 'B', false, 'C', w);
-    pda.add_rule(3, 2, PUSH, 'C', false, 'A', w);
+    pda.add_rule(0, 1, PUSH, 'B', 'A', w);
+    pda.add_rule(0, 0, POP , '*', 'B', w);
+    pda.add_rule(1, 3, SWAP, 'A', 'B', w);
+    pda.add_rule(2, 0, SWAP, 'B', 'C', w);
+    pda.add_rule(3, 2, PUSH, 'C', 'A', w);
 
     std::vector<char> init_stack{'B', 'A', 'A', 'A'};
     PAutomaton automaton(pda, 1, pda.encode_pre(init_stack));


### PR DESCRIPTION
Construct the pushdown system from rules, and let the initial and final headers be represented by PAutomata. 
post* and pre* now rely on computing the product automaton on-the-fly to check for non-empty intersection. This still supports early termination. 