### PR TITLE
Dual Search

### DIFF
--- a/src/pdaaal/Solver.h
+++ b/src/pdaaal/Solver.h
@@ -524,6 +524,17 @@ namespace pdaaal {
                        return instance.add_edge_product(from, label, to, trace);
                    });
         }
+        template <Trace_Type trace_type = Trace_Type::Any, typename pda_t, typename automaton_t, typename T, typename W, typename C, typename A>
+        static bool post_star_accepts_no_ET(SolverInstance_impl<pda_t,automaton_t,T,W,C,A>& instance) {
+            post_star<trace_type,W,C,A,false>(instance.automaton());
+            return instance.initialize_product();
+        }
+        template <typename pda_t, typename automaton_t, typename T, typename W, typename C, typename A>
+        static bool pre_star_accepts_no_ET(SolverInstance_impl<pda_t,automaton_t,T,W,C,A>& instance) {
+            instance.enable_pre_star();
+            pre_star<W,C,A,false>(instance.automaton());
+            return instance.initialize_product();
+        }
 
         template <Trace_Type trace_type = Trace_Type::Any, typename T, typename W, typename C, typename A>
         static auto get_trace(const SolverInstance<T,W,C,A>& instance) {

--- a/test/ParsingPDAFactory_test.cpp
+++ b/test/ParsingPDAFactory_test.cpp
@@ -424,3 +424,48 @@ A,B,C
     BOOST_CHECK(std::all_of(trace.begin(), trace.end(), [](const auto& trace_state){ return trace_state._stack.back() == "C"; }));
     print_trace<std::string>(trace);
 }
+
+
+BOOST_AUTO_TEST_CASE(DualSearch_Test)
+{
+    std::istringstream i_stream(R"(
+# You can make a comment like this
+
+# Labels
+A,B
+# Initial states
+0
+# Accepting states
+0
+# Rules
+0 A -> 2 B
+0 B -> 0 A
+0 A -> 1 -
+1 B -> 2 +B
+2 B -> 0 -
+
+# POP  rules use -
+# PUSH rules use +LABEL
+# SWAP rules use LABEL
+)");
+    auto factory = ParsingPDAFactory<>::create(i_stream);
+
+    // initial stack: [A,B]
+    NFA<std::string> initial(std::unordered_set<std::string>{"A"});
+    NFA<std::string> temp(std::unordered_set<std::string>{"B"});
+    initial.concat(std::move(temp));
+    // final stack: [A]
+    NFA<std::string> final(std::unordered_set<std::string>{"A"});
+    // Yeah, a small regex -> NFA parser could be nice here...
+
+    auto instance = factory.compile(initial, final);
+
+    bool result = Solver::dual_search_accepts(instance);
+    BOOST_CHECK(result);
+
+    auto trace = Solver::get_trace(instance);
+    BOOST_CHECK_GE(trace.size(), 4);
+    BOOST_CHECK_LE(trace.size(), 5);
+
+    print_trace<std::string>(trace);
+}

--- a/test/ParsingPDAFactory_test.cpp
+++ b/test/ParsingPDAFactory_test.cpp
@@ -463,7 +463,7 @@ A,B
     bool result = Solver::dual_search_accepts(instance);
     BOOST_CHECK(result);
 
-    auto trace = Solver::get_trace(instance);
+    auto trace = Solver::get_trace_dual_search(instance);
     BOOST_CHECK_GE(trace.size(), 4);
     BOOST_CHECK_LE(trace.size(), 5);
 

--- a/test/ParsingPDAFactory_test.cpp
+++ b/test/ParsingPDAFactory_test.cpp
@@ -469,3 +469,50 @@ A,B
 
     print_trace<std::string>(trace);
 }
+
+BOOST_AUTO_TEST_CASE(Complete_CEGAR_dualsearch_Full_Abstraction_Test)
+{
+    std::istringstream i_stream(R"(
+# Labels
+A,B,C
+# Initial states
+0
+# Accepting states
+0
+# Rules
+0 A -> 2 B
+0 B -> 0 A
+0 A -> 1 -
+1 B -> 2 +B
+2 B -> 0 -
+
+# POP  rules use -
+# PUSH rules use +LABEL
+# SWAP rules use LABEL
+)");
+    auto factory = ParsingCegarPdaFactory<>::create(i_stream,
+                                                    [](const auto& label){ return 0; }, // All labels map to 0.
+                                                    [](const auto& s){ return 0; }); // All states map to 0.
+
+    // initial stack: [A,B,C]
+    NFA<std::string> initial(std::unordered_set<std::string>{"A"});
+    NFA<std::string> temp1(std::unordered_set<std::string>{"B"});
+    NFA<std::string> temp2(std::unordered_set<std::string>{"C"});
+    initial.concat(std::move(temp1));
+    initial.concat(std::move(temp2));
+    // final stack: [A,C]
+    NFA<std::string> final(std::unordered_set<std::string>{"A"});
+    NFA<std::string> temp3(std::unordered_set<std::string>{"C"});
+    final.concat(std::move(temp3));
+    // Yeah, a small regex -> NFA parser could be nice here...
+
+    CEGAR<ParsingCegarPdaFactory<>,ParsingCegarPdaReconstruction<>> cegar;
+    auto res = cegar.cegar_solve<false,true>(std::move(factory), initial, final);
+    BOOST_CHECK(res.has_value());
+    auto trace = res.value();
+
+    BOOST_CHECK_GE(trace.size(), 4);
+    BOOST_CHECK_LE(trace.size(), 5);
+    BOOST_CHECK(std::all_of(trace.begin(), trace.end(), [](const auto& trace_state){ return trace_state._stack.back() == "C"; }));
+    print_trace<std::string>(trace);
+}


### PR DESCRIPTION
- Add dual_search which interleaves pre* and post* saturation procedures. (Experiments show this provides a significant average-case performance boost.)
- Refactoring of Solver