### PR TITLE
Move find_path[_shortest] to PAutomaton + fix algorithm + make AutomatonPath nullable

### DIFF
--- a/src/include/pdaaal/AutomatonPath.h
+++ b/src/include/pdaaal/AutomatonPath.h
@@ -39,7 +39,21 @@ namespace pdaaal {
         state_t _end{};
         std::vector<std::pair<uint32_t,state_t>> _edges{};
     public:
-        explicit AutomatonPath(state_t end) : _end(end) {};
+        AutomatonPath() {
+            if constexpr(state_pair) {
+                _end = std::make_pair(std::numeric_limits<size_t>::max(),std::numeric_limits<size_t>::max());
+            } else {
+                _end = std::numeric_limits<size_t>::max();
+            }
+        }
+        explicit AutomatonPath(state_t end) : _end(end) {
+            if constexpr(state_pair) {
+                assert(_end.first != std::numeric_limits<size_t>::max());
+                assert(_end.second != std::numeric_limits<size_t>::max());
+            } else {
+                assert(_end != std::numeric_limits<size_t>::max());
+            }
+        };
         AutomatonPath(const std::vector<state_t>& path, const std::vector<uint32_t>& stack)
         : _end(path.back()) {
             assert(path.size() == stack.size() + 1);
@@ -50,6 +64,13 @@ namespace pdaaal {
             }
         }
 
+        [[nodiscard]] bool is_null() const {
+            if constexpr(state_pair) {
+                return _end.first == std::numeric_limits<size_t>::max() && _end.second == std::numeric_limits<size_t>::max();
+            } else {
+                return _end == std::numeric_limits<size_t>::max();
+            }
+        }
         [[nodiscard]] bool empty() const {
             return _edges.empty();
         }
@@ -68,6 +89,7 @@ namespace pdaaal {
             _edges.pop_back();
         }
         void emplace(state_t from, uint32_t label) {
+            assert(!is_null());
             _edges.emplace_back(label, from);
         }
         [[nodiscard]] std::vector<uint32_t> stack() const {
@@ -116,6 +138,11 @@ namespace pdaaal {
             return H::combine(std::move(h), p._end, p._edges);
         }
     };
+
+    AutomatonPath(size_t end) -> AutomatonPath<false>;
+    AutomatonPath(std::pair<size_t,size_t> end) -> AutomatonPath<true>;
+    AutomatonPath(const std::vector<size_t>& path, const std::vector<uint32_t>& stack) -> AutomatonPath<false>;
+    AutomatonPath(const std::vector<std::pair<size_t,size_t>>& path, const std::vector<uint32_t>& stack) -> AutomatonPath<true>;
 
 }
 

--- a/src/include/pdaaal/PAutomaton.h
+++ b/src/include/pdaaal/PAutomaton.h
@@ -31,6 +31,7 @@
 #include <pdaaal/utils/fut_set.h>
 #include <pdaaal/NFA.h>
 #include <pdaaal/Weight.h>
+#include <pdaaal/AutomatonPath.h>
 
 #include <memory>
 #include <functional>
@@ -353,6 +354,136 @@ namespace pdaaal {
                 out << "\" [style=invisible];\n";
             }
             out << "}\n";
+        }
+
+        // Find_path searches for an accepting path.
+        // The state_map function allows us to use this in PAutomatonProduct as well.
+        [[nodiscard]] auto find_path() const { return find_path([](size_t s){ return s; }); }
+        template <typename Fn> [[nodiscard]] auto find_path(Fn&& state_map) const {
+            using path_state = decltype(std::declval<Fn>()(std::declval<size_t>()));
+            static_assert(std::is_convertible_v<Fn, std::function<path_state(size_t)>>);
+            using automaton_path_t = decltype(AutomatonPath(std::declval<path_state>()));
+
+            // DFS search.
+            std::vector<path_state> path;
+            std::vector<uint32_t> label_stack;
+            std::vector<std::tuple<size_t,size_t,uint32_t>> waiting; // state_id, stack_index, last_label (if stack_index > 0)
+            const size_t pda_size = _pda.states().size();
+            waiting.reserve(pda_size);
+            for (size_t i = 0; i < pda_size; ++i) {
+                if (_states[i]->_accepting) { // Initial accepting state
+                    return automaton_path_t(state_map(i));
+                }
+                waiting.emplace_back(i, 0, std::numeric_limits<uint32_t>::max()); // Add all initial states.
+            }
+            std::unordered_set<size_t> seen;
+
+            while (!waiting.empty()) {
+                auto [current, stack_index, last_label] = waiting.back();
+                waiting.pop_back();
+                path.resize(stack_index + 2);
+                label_stack.resize(stack_index + 1);
+                path[stack_index] = state_map(current);
+                if (stack_index > 0) {
+                    label_stack[stack_index - 1] = last_label;
+                }
+                for (const auto &[to,labels] : _states[current]->_edges) {
+                    if (!labels.empty() && seen.emplace(to).second) {
+                        uint32_t label = labels[0].first;
+                        if (_states[to]->_accepting) {
+                            path[stack_index + 1] = state_map(to);
+                            label_stack[stack_index] = label;
+                            return automaton_path_t(path, label_stack); // No nice way of creating this on the fly, so we do it in the end.
+                        }
+                        waiting.emplace_back(to, stack_index + 1, label);
+                    }
+                }
+            }
+            return automaton_path_t();
+        }
+
+        [[nodiscard]] auto find_path_shortest() const { return find_path_shortest([](size_t s){ return s; }); }
+        template <typename Fn> [[nodiscard]] auto find_path_shortest(Fn&& state_map) const {
+            using path_state = decltype(std::declval<Fn>()(std::declval<size_t>()));
+            static_assert(std::is_convertible_v<Fn, std::function<path_state(size_t)>>);
+            using automaton_path_t = decltype(AutomatonPath(std::declval<path_state>()));
+
+            if constexpr (is_weighted<W>) { // TODO: Consider unweighted shortest path.
+                // Dijkstra.
+                struct queue_elem {
+                    typename W::type weight;
+                    size_t state;
+                    uint32_t label;
+                    const queue_elem* back_pointer;
+
+                    queue_elem(typename W::type weight, size_t state, uint32_t label, const queue_elem* back_pointer = nullptr)
+                            : weight(weight), state(state), label(label), back_pointer(back_pointer) {};
+
+                    bool operator<(const queue_elem& other) const {
+                        return std::tie(state, label) < std::tie(other.state, other.label); // TODO: Is this correct? Should it not just be state?? and better then make 'visited' std::unordered_map<size_t, typename W::type>.
+                    }
+                    bool operator==(const queue_elem& other) const {
+                        return state == other.state && label == other.label;
+                    }
+                    bool operator!=(const queue_elem& other) const {
+                        return !(*this == other);
+                    }
+                };
+                struct queue_elem_comp {
+                    bool operator()(const queue_elem& lhs, const queue_elem& rhs) {
+                        return solver_weight<W, Trace_Type::Shortest>::less(rhs.weight, lhs.weight); // Used in a max-heap, so swap arguments to make it a min-heap.
+                    }
+                };
+                std::priority_queue<queue_elem, std::vector<queue_elem>, queue_elem_comp> search_queue;
+                std::vector<queue_elem> visited;
+                std::vector<std::unique_ptr<queue_elem>> pointers;
+                const size_t pda_size = _pda.states().size();
+                for (size_t i = 0; i < pda_size; ++i) { // Iterate over _initial ([i]->_id)
+                    search_queue.emplace(W::zero(), i, std::numeric_limits<uint32_t>::max()); // No label going into initial state.
+                }
+                while (!search_queue.empty()) {
+                    auto current = search_queue.top();
+                    search_queue.pop();
+
+                    if (_states[current.state]->_accepting) {
+                        AutomatonPath automaton_path(state_map(current.state));
+                        const queue_elem* p = &current;
+                        while (p->back_pointer != nullptr) {
+                            auto label = p->label;
+                            p = p->back_pointer;
+                            automaton_path.emplace(state_map(p->state), label);
+                        }
+                        return std::make_tuple(std::move(automaton_path), current.weight);
+                    }
+
+                    auto lb = std::lower_bound(visited.begin(), visited.end(), current);
+                    if (lb != std::end(visited) && *lb == current) {
+                        if (solver_weight<W, Trace_Type::Shortest>::less(current.weight, lb->weight)) {
+                            *lb = current;
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        lb = visited.insert(lb, current); // TODO: Consider using std::unordered_map instead...
+                    }
+                    auto u_pointer = std::make_unique<queue_elem>(*lb);
+                    auto pointer = u_pointer.get();
+                    pointers.push_back(std::move(u_pointer));
+                    for (const auto& [to, labels] : _states[current.state]->_edges) {
+                        if (!labels.empty()) {
+                            auto label = std::min_element(labels.begin(), labels.end(), [](const auto& a, const auto& b) {
+                                return solver_weight<W, Trace_Type::Shortest>::less(a.second.second, b.second.second);
+                            });
+                            search_queue.emplace(solver_weight<W, Trace_Type::Shortest>::add(current.weight, label->second.second), to, label->first, pointer);
+                        }
+                    }
+                }
+                return std::make_tuple(automaton_path_t(), solver_weight<W, Trace_Type::Shortest>::max());
+
+            } else {
+                assert(false);
+                throw std::logic_error("Not implemented: Shortest path for unweighted automaton.");
+            }
         }
 
         [[nodiscard]] bool accepts(size_t state, const std::vector<uint32_t> &stack) const {

--- a/src/include/pdaaal/PDA.cpp
+++ b/src/include/pdaaal/PDA.cpp
@@ -42,6 +42,7 @@ namespace pdaaal {
         assert(std::is_sorted(other.begin(), other.end()));
         std::vector<uint32_t> temp_labels;
         temp_labels.swap(_labels);
+        _labels.reserve(std::max(temp_labels.size(), other.size()));
         std::set_union(temp_labels.begin(), temp_labels.end(),
                        other.begin(), other.end(),
                        std::back_inserter(_labels));

--- a/test/Verification_test.cpp
+++ b/test/Verification_test.cpp
@@ -566,9 +566,9 @@ BOOST_AUTO_TEST_CASE(Verification_longest_trace_arithmetic_3_5_test)
     auto [trace, weight] = Solver::get_trace<Trace_Type::Longest>(instance);
     BOOST_CHECK_EQUAL(w, weight);
 
-    BOOST_CHECK(automaton_path.has_value());
+    BOOST_CHECK(!automaton_path.is_null());
     // TODO: Test instead of printing
-    details::TraceBack tb(instance.automaton(), std::move(automaton_path).value());
+    details::TraceBack tb(instance.automaton(), std::move(automaton_path));
     std::unordered_set<std::tuple<size_t,uint32_t,size_t>, absl::Hash<std::tuple<size_t,uint32_t,size_t>>> seen_front;
     while (seen_front.emplace(tb.path().front_edge()).second) {
         print_conf_path(s, tb.path(), pda);
@@ -654,9 +654,9 @@ BOOST_AUTO_TEST_CASE(Verification_longest_trace_arithmetic_3_3or5_test)
     auto [trace, weight] = Solver::get_trace<Trace_Type::Longest>(instance);
     BOOST_CHECK_EQUAL(w, weight);
 
-    BOOST_CHECK(automaton_path.has_value());
+    BOOST_CHECK(!automaton_path.is_null());
     // TODO: Test instead of printing
-    details::TraceBack tb(instance.automaton(), std::move(automaton_path).value());
+    details::TraceBack tb(instance.automaton(), std::move(automaton_path));
     std::unordered_set<std::tuple<size_t,uint32_t,size_t>, absl::Hash<std::tuple<size_t,uint32_t,size_t>>> seen_front;
     while (seen_front.emplace(tb.path().front_edge()).second) {
         print_conf_path(s, tb.path(), pda);
@@ -714,9 +714,9 @@ BOOST_AUTO_TEST_CASE(Verification_longest_trace_which_pop_seq_test)
     auto [trace, weight] = Solver::get_trace<Trace_Type::Longest>(instance);
     BOOST_CHECK_EQUAL(w, weight);
 
-    BOOST_CHECK(automaton_path.has_value());
+    BOOST_CHECK(!automaton_path.is_null());
     // TODO: Test instead of printing
-    details::TraceBack tb(instance.automaton(), std::move(automaton_path).value());
+    details::TraceBack tb(instance.automaton(), std::move(automaton_path));
     std::unordered_set<std::tuple<size_t,uint32_t,size_t>, absl::Hash<std::tuple<size_t,uint32_t,size_t>>> seen_front;
     while (seen_front.emplace(tb.path().front_edge()).second) {
         print_conf_path(s, tb.path(), pda);
@@ -797,9 +797,9 @@ BOOST_AUTO_TEST_CASE(Verification_longest_trace_hill_test)
     BOOST_CHECK_NE(pXq, nullptr);
     BOOST_CHECK_EQUAL(pXq->second, max_weight<uint32_t>::bottom());
 
-    BOOST_CHECK(automaton_path.has_value());
+    BOOST_CHECK(!automaton_path.is_null());
     // TODO: Test instead of printing
-    details::TraceBack tb(instance.automaton(), std::move(automaton_path).value());
+    details::TraceBack tb(instance.automaton(), std::move(automaton_path));
     std::unordered_set<std::tuple<size_t,uint32_t,size_t>, absl::Hash<std::tuple<size_t,uint32_t,size_t>>> seen_front;
     while (seen_front.emplace(tb.path().front_edge()).second) {
         print_conf_path(s, tb.path(), pda);
@@ -848,9 +848,9 @@ BOOST_AUTO_TEST_CASE(Verification_longest_trace_start_hill_end_test)
     auto [automaton_path, w] = instance.find_path<Trace_Type::Longest>();
     BOOST_CHECK_EQUAL(w, max_weight<uint32_t>::bottom());
 
-    BOOST_CHECK(automaton_path.has_value());
+    BOOST_CHECK(!automaton_path.is_null());
     // TODO: Test instead of printing
-    details::TraceBack tb(instance.automaton(), std::move(automaton_path).value());
+    details::TraceBack tb(instance.automaton(), std::move(automaton_path));
     std::unordered_set<std::tuple<size_t,uint32_t,size_t>, absl::Hash<std::tuple<size_t,uint32_t,size_t>>> seen_front;
     while (seen_front.emplace(tb.path().front_edge()).second) {
         print_conf_path(s, tb.path(), pda);


### PR DESCRIPTION
The functions find_path and find_path_shortest belongs to PAutomaton, not PAutomatonProduct.
Use std::unordered_map for visited states in Dijkstra's (find_path_shortest). 
A null state in AutomatonPath simplifies some function interfaces.