### PR TITLE
Fix bug in post* shortest trace

### DIFF
--- a/src/include/pdaaal/Solver.h
+++ b/src/include/pdaaal/Solver.h
@@ -135,7 +135,7 @@ namespace pdaaal {
         static bool post_star_accepts(PAutomatonProduct<pda_t,automaton_t,W>& instance) {
             return instance.initialize_product() ||
                    post_star<trace_type,W,true>(instance.automaton(), [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) -> bool {
-                       return instance.add_edge_product(from, label, to, trace);
+                       return instance.template add_edge_product<trace_type != Trace_Type::Shortest>(from, label, to, trace);
                    });
         }
 

--- a/src/include/pdaaal/internal/PdaSaturation.h
+++ b/src/include/pdaaal/internal/PdaSaturation.h
@@ -615,7 +615,7 @@ namespace pdaaal::internal {
                 for (auto &e : _rel3[i - _n_Q]) {
                     assert(e._label != epsilon);
                     _automaton.add_edge(i, e._to, e._label, std::make_pair(e._trace, e._weight));
-                    if constexpr (ET) { // TODO: We might need to do this in main loop (and update weights) to enable early termination in some cases..??
+                    if constexpr (ET) { // TODO: We might need to do this in main loop (and update weights) to enable early termination in some cases..?? <-- Yes, that is correct. Test case found.
                         _found |= _early_termination(i, e._label, e._to, std::make_pair(e._trace, e._weight));
                     }
                 }


### PR DESCRIPTION
Early termination during construction of product automata could stop when a non-shortest path was found in the product automata, hence the shortest path was not present in the automata. 
Now we complete the product automata construction, so the shortest path can be found. 
Performance impact of this is minimal.

(Performance could be improved by a better (correct) early termination for weighted product automata - left for future)