### PR TITLE
Fix bug in P-automaton JSON parser

### DIFF
--- a/test/Parser_test.cpp
+++ b/test/Parser_test.cpp
@@ -45,6 +45,7 @@ BOOST_AUTO_TEST_CASE(PAutomatonFromJson_OldFormat_Test)
         ]
     }})");
     auto automaton = parsing::PAutomatonJsonParser_Old::parse<>(automaton_stream, pda);
+    BOOST_CHECK_EQUAL(automaton.states().size(), 3);
     std::vector<uint32_t> stack; stack.emplace_back(0);
     bool result = Solver::post_star_accepts(automaton, 0, stack);
     BOOST_CHECK(result);
@@ -64,6 +65,7 @@ BOOST_AUTO_TEST_CASE(PAutomatonFromJson_NewFormat_Test)
         ]
     }})");
     auto automaton = parsing::PAutomatonJsonParser::parse<>(automaton_stream, pda);
+    BOOST_CHECK_EQUAL(automaton.states().size(), 3);
     std::vector<uint32_t> stack; stack.emplace_back(0);
     bool result = Solver::post_star_accepts(automaton, 0, stack);
     BOOST_CHECK(result);


### PR DESCRIPTION
Non-initial states in the automaton were in some cases mapped incorrectly in the parser. Fixed.
Also adds test the catches the bug.