### PR TITLE
Fix PAutomaton to_dot with vector_printer

### DIFF
--- a/src/include/pdaaal/PAutomatonProduct.h
+++ b/src/include/pdaaal/PAutomatonProduct.h
@@ -104,6 +104,22 @@ namespace pdaaal {
         [[nodiscard]] const product_automaton_t& product_automaton() const {
             return _product;
         }
+        template<Trace_Type trace_type = Trace_Type::None>
+        void automaton_to_dot(std::ostream &out) {
+            automaton_to_dot<trace_type>(out, automaton());
+        }
+        template<Trace_Type trace_type = Trace_Type::None>
+        void product_automaton_to_dot(std::ostream &out) {
+            automaton_to_dot<trace_type>(out, product_automaton());
+        }
+        template<Trace_Type trace_type = Trace_Type::None, typename aut_t>
+        void automaton_to_dot(std::ostream &out, const aut_t& automaton) {
+            automaton.template to_dot<trace_type>(out,
+                [this](std::ostream& s, const uint32_t& label){ s << pda().get_symbol(label); },
+                [this,pda_size=pda().states().size()](std::ostream& s, const size_t& state_id){
+                    state_id < pda_size ? s << pda().get_state(state_id) : s << state_id;
+            });
+        }
 
         const pda_t& pda() const {
             return _pda;

--- a/src/include/pdaaal/internal/PAutomaton.h
+++ b/src/include/pdaaal/internal/PAutomaton.h
@@ -30,6 +30,7 @@
 #include "PDA.h"
 #include "pdaaal/NFA.h"
 #include "pdaaal/AutomatonPath.h"
+#include "pdaaal/utils/vector_printer.h"
 #include <memory>
 #include <functional>
 #include <vector>
@@ -306,7 +307,11 @@ namespace pdaaal::internal {
                                     }
                                 }
                                 if (!special_weight) {
-                                    out << "(" << tw.second << ")";
+                                    if constexpr(W::is_vector) {
+                                        out << "(" << vector_printer() << tw.second << ")";
+                                    } else {
+                                        out << "(" << tw.second << ")";
+                                    }
                                 }
                             }
                             out << "\\]";
@@ -331,7 +336,11 @@ namespace pdaaal::internal {
                         if (labels.size() > 1) out << " ";
                         out << "𝜀";
                         if constexpr(is_weighted<W>) {
-                            out << "(" << labels.find(epsilon)->second.second << ")";
+                            if constexpr(W::is_vector) {
+                                out << "(" << vector_printer() << labels.find(epsilon)->second.second << ")";
+                            } else {
+                                out << "(" << labels.find(epsilon)->second.second << ")";
+                            }
                         }
                     }
                     out << "\"];\n";

--- a/src/include/pdaaal/utils/vector_printer.h
+++ b/src/include/pdaaal/utils/vector_printer.h
@@ -1,0 +1,73 @@
+/* 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *  Copyright Morten K. Schou
+ */
+
+/* 
+ * File:   vector_printer.h
+ * Author: Morten K. Schou <morten@h-schou.dk>
+ *
+ * Created on 22-04-2022.
+ */
+
+#ifndef PDAAAL_VECTOR_PRINTER_H
+#define PDAAAL_VECTOR_PRINTER_H
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace pdaaal {
+    class vector_printer {
+    public:
+        vector_printer() = default;
+        explicit vector_printer(std::string separator) : _separator(std::move(separator)) {};
+        vector_printer(std::string start, std::string end) : _start(std::move(start)), _end(std::move(end)) {};
+        vector_printer(std::string start, std::string separator, std::string end)
+        : _start(std::move(start)), _separator(std::move(separator)), _end(std::move(end)) {};
+
+    private:
+        vector_printer(std::ostream& o, const vector_printer& vp)
+        : _o(o), _start(vp._start), _separator(vp._separator), _end(vp._end) {};
+
+        friend vector_printer operator<<(std::ostream& o, const vector_printer& vp) {
+            return {o,vp};
+        }
+        template<typename T>
+        friend std::ostream& operator<<(vector_printer vp, const std::vector<T>& v) {
+            vp._o << vp._start;
+            bool first = true;
+            for (auto&& elem : v) {
+                if (first) first = false;
+                else vp._o << vp._separator;
+                vp._o << elem;
+            }
+            vp._o << vp._end;
+            return vp._o;
+        }
+
+    private:
+        std::ostream& _o = std::cout;
+        std::string _start = "[";
+        std::string _separator = ",";
+        std::string _end = "]";
+    };
+
+}
+
+#endif //PDAAAL_VECTOR_PRINTER_H


### PR DESCRIPTION
Make to_dot work for PAutomata with vector weights. 
Add utils/vector_printer.h as a convenience class.