### PR TITLE
Add longest trace post* engine + interleaved pre*/post* fixed-point

### DIFF
--- a/src/include/pdaaal/PAutomatonProduct.h
+++ b/src/include/pdaaal/PAutomatonProduct.h
@@ -56,6 +56,12 @@ namespace pdaaal {
           _product(std::move(other._product), _pda), _swap_initial_final(other._swap_initial_final), _id_map(std::move(other._id_map)),
           _id_fast_lookup(std::move(other._id_fast_lookup)), _id_fast_lookup_back(std::move(other._id_fast_lookup_back)) {};
 
+        auto copy() {
+            auto initial_automaton_copy = initial_automaton();
+            auto final_automaton_copy = final_automaton();
+            return PAutomatonProduct(pda(), std::move(initial_automaton_copy), std::move(final_automaton_copy));
+        }
+
         // Returns whether an accepting state in the product automaton was reached.
         template<bool needs_back_lookup = false, bool ET = true>
         bool initialize_product() {

--- a/src/include/pdaaal/Solver.h
+++ b/src/include/pdaaal/Solver.h
@@ -60,6 +60,27 @@ namespace pdaaal {
             saturation.run();
         }
 
+        template <Trace_Type trace_type, typename pda_t, typename automaton_t, typename W>
+        static std::pair<bool,bool> interleaving_fixed_point_accepts(PAutomatonProduct<pda_t,automaton_t,W,TraceInfoType::Pair>& instance,
+                                                     PAutomatonProduct<pda_t,automaton_t,W,TraceInfoType::Pair>& instance_copy) {
+            instance_copy.enable_pre_star();
+            internal::PreStarFixedPointSaturation<W,trace_type> pre_star(instance_copy.automaton());
+            internal::PostStarFixedPointSaturation<W,trace_type> post_star(instance.automaton());
+
+            while(!pre_star.done() && !post_star.done()) {
+                post_star.step();
+                pre_star.step();
+            }
+            if (pre_star.done()) {
+                pre_star.finalize();
+                return std::make_pair(instance_copy.template initialize_product<false,false>(), true);
+            } else {
+                assert(post_star.done());
+                post_star.finalize();
+                return std::make_pair(instance.template initialize_product<false,false>(), false);
+            }
+        }
+
         template <typename pda_t, typename automaton_t, typename W>
         static bool dual_search_accepts(PAutomatonProduct<pda_t,automaton_t,W>& instance) {
             if (instance.template initialize_product<true>()) {

--- a/src/include/pdaaal/Solver.h
+++ b/src/include/pdaaal/Solver.h
@@ -49,6 +49,17 @@ namespace pdaaal {
             saturation.run();
         }
 
+        template <Trace_Type trace_type, typename pda_t, typename automaton_t, typename W>
+        static bool post_star_fixed_point_accepts(PAutomatonProduct<pda_t,automaton_t,W,TraceInfoType::Pair>& instance) {
+            post_star_fixed_point<trace_type>(instance.automaton());
+            return instance.template initialize_product<false,false>();
+        }
+        template <Trace_Type trace_type, typename W>
+        static void post_star_fixed_point(internal::PAutomaton<W,TraceInfoType::Pair>& automaton) {
+            internal::PostStarFixedPointSaturation<W,trace_type> saturation(automaton);
+            saturation.run();
+        }
+
         template <typename pda_t, typename automaton_t, typename W>
         static bool dual_search_accepts(PAutomatonProduct<pda_t,automaton_t,W>& instance) {
             if (instance.template initialize_product<true>()) {

--- a/src/include/pdaaal/Solver.h
+++ b/src/include/pdaaal/Solver.h
@@ -187,7 +187,8 @@ namespace pdaaal {
             if constexpr (trace_type == Trace_Type::Longest || trace_type == Trace_Type::ShortestFixedPoint) {
                 using return_type = decltype(_get_trace(instance.pda(), instance.initial_automaton(), std::declval<AutomatonPath<>>()));
                 auto [automaton_path, weight] = instance.template find_path_fixed_point<trace_type>();
-                if (weight != internal::solver_weight<W,trace_type>::bottom()) { // Not infinite. Use standard _get_trace.
+                if ((trace_type == Trace_Type::ShortestFixedPoint && !W::is_signed) // For unsigned shortest-fixed-point, bottom==0 is not infinite.
+                    || weight != internal::solver_weight<W,trace_type>::bottom()) { // Not infinite. Use standard _get_trace.
                     return std::make_pair(_get_trace(instance.pda(), instance.automaton(), automaton_path), weight);
                 }
                 // Infinite trace.

--- a/src/include/pdaaal/internal/PAutomatonAlgorithms.h
+++ b/src/include/pdaaal/internal/PAutomatonAlgorithms.h
@@ -33,11 +33,11 @@
 namespace pdaaal::internal {
 
     template<typename W, Trace_Type trace_type>
-    class PAutomatonFixedPoint : public fixed_point_workset<PAutomatonFixedPoint<W, trace_type>, size_t> {
+    class PAutomatonFixedPoint : public fixed_point_workset<PAutomatonFixedPoint<W, trace_type>, size_t, false> {
         static constexpr size_t uninitialized_state = std::numeric_limits<size_t>::max();
         static constexpr size_t no_state = std::numeric_limits<size_t>::max() - 1;
 
-        using parent_t = fixed_point_workset<PAutomatonFixedPoint<W, trace_type>, size_t>;
+        using parent_t = fixed_point_workset<PAutomatonFixedPoint<W, trace_type>, size_t, false>;
         using solverW = solver_weight<W,trace_type>;
         struct state_info {
             typename W::type weight = solverW::max();
@@ -51,8 +51,6 @@ namespace pdaaal::internal {
         std::vector<state_info> _states;
         size_t _min_accepting_state = uninitialized_state; // Id of accept state with minimum path weight to it. (keep it updated).
     public:
-        static constexpr size_t next_round_elem = std::numeric_limits<size_t>::max(); // Needs to be different from any proper queue element.
-
         explicit PAutomatonFixedPoint(const PAutomaton<W, TraceInfoType::Pair>& automaton)
         : parent_t(automaton.states().size()),
         _automaton(automaton), _states(_automaton.states().size()) {

--- a/src/include/pdaaal/internal/PdaSaturation.h
+++ b/src/include/pdaaal/internal/PdaSaturation.h
@@ -817,7 +817,6 @@ namespace pdaaal::internal {
         size_t _n_automaton_states{};
         std::vector<std::vector<std::pair<size_t,uint32_t>>> _rel1; // faster access for lookup _from -> (_to, _label)
         std::vector<std::vector<size_t>> _rel2; // faster access for lookup _to -> _from  (when _label is epsilon)
-        std::vector<typename W::type> _minpath;
 
         size_t _count_transitions = 0;
 
@@ -855,8 +854,6 @@ namespace pdaaal::internal {
                 }
             }
             parent_t::set_round_limit(_count_transitions);
-            _minpath.resize(_n_automaton_states - _n_Q);
-            std::fill(_minpath.begin(), _minpath.end(), solverW::max());
         }
 
         void insert_rel(size_t from, uint32_t label, size_t to) {

--- a/src/include/pdaaal/internal/PdaSaturation.h
+++ b/src/include/pdaaal/internal/PdaSaturation.h
@@ -645,6 +645,7 @@ namespace pdaaal::internal {
             } else {
                 auto [it, fresh] = _automaton.emplace_edge(from, label, to, std::make_pair(std::make_pair(trace,trace), edge_weight));
                 if (fresh) {
+                    ++_count_transitions; parent_t::set_round_limit(_count_transitions);
                     _rel[from].emplace_back(to, label); // Allow fast iteration over _edges matching specific from.
                     is_changed = true;
                 } else {
@@ -686,7 +687,6 @@ namespace pdaaal::internal {
                   _rel(_n_automaton_states), _delta_prime(_n_automaton_states) {
             initialize();
         };
-        static constexpr temp_edge_t next_round_elem = temp_edge_t();
     private:
         p_automaton_t& _automaton;
         const std::vector<typename PDA<W>::state_t>& _pda_states;
@@ -697,6 +697,8 @@ namespace pdaaal::internal {
         std::vector<std::vector<std::pair<size_t,uint32_t>>> _rel; // Fast access to _edges based on _from.
         std::vector<fut::vector_set<std::pair<size_t, size_t>>> _delta_prime;
 
+        size_t _count_transitions = 0;
+
         void initialize() {
             for (const auto& from : _automaton.states()) {
                 for (const auto& [to,labels] : from->_edges) {
@@ -704,6 +706,7 @@ namespace pdaaal::internal {
                         assert(tw == std::make_pair(trace_info::make_default(), W::zero()));
                         _rel[from->_id].emplace_back(to, label); // Allow fast iteration over _edges matching specific from.
                         parent_t::emplace(from->_id, label, to);
+                        ++_count_transitions;
                     }
                 }
             }
@@ -717,6 +720,7 @@ namespace pdaaal::internal {
                     ++rule_id;
                 }
             }
+            parent_t::set_round_limit(_count_transitions);
         }
 
     public:
@@ -803,7 +807,6 @@ namespace pdaaal::internal {
           _n_pda_states(_pda_states.size()), _n_Q(_automaton.states().size()) {
             initialize();
         };
-        static constexpr temp_edge_t next_round_elem = temp_edge_t();
     private:
         p_automaton_t& _automaton;
         const std::vector<typename PDA<W>::state_t>& _pda_states;

--- a/src/include/pdaaal/utils/workset.h
+++ b/src/include/pdaaal/utils/workset.h
@@ -37,7 +37,7 @@ namespace pdaaal {
     class fixed_point_workset {
         static constexpr Elem next_round_elem = Derived::next_round_elem;
         bool _done = false;
-        const size_t _round_limit;
+        size_t _round_limit;
         size_t _rounds = 0;
         std::deque<Elem> _workset;
     public:
@@ -87,6 +87,7 @@ namespace pdaaal {
         auto emplace(Args&&... args){
             return _workset.emplace_back(std::forward<Args>(args)...);
         }
+        void set_round_limit(size_t new_round_limit) { _round_limit = new_round_limit; }
     };
 }
 

--- a/src/pdaaal-bin/Verifier.h
+++ b/src/pdaaal-bin/Verifier.h
@@ -208,7 +208,7 @@ namespace pdaaal {
                                     std::tie(trace, weight) = Solver::get_trace<Trace_Type::ShortestFixedPoint>(instance);
                                     reachability_time.stop(); // We don't want to include time for output in reachability_time.
                                     using W = typename pda_t::weight;
-                                    if (weight == internal::solver_weight<W,Trace_Type::ShortestFixedPoint>::bottom()) {
+                                    if (W::is_signed && weight == internal::solver_weight<W,Trace_Type::ShortestFixedPoint>::bottom()) {
                                         json_out.entry("weight", "negative infinity");
                                     } else {
                                         json_out.entry("weight", weight);
@@ -243,7 +243,7 @@ namespace pdaaal {
                                     std::tie(trace, weight) = Solver::get_trace<Trace_Type::ShortestFixedPoint>(instance);
                                     reachability_time.stop(); // We don't want to include time for output in reachability_time.
                                     using W = typename pda_t::weight;
-                                    if (weight == internal::solver_weight<W,Trace_Type::ShortestFixedPoint>::bottom()) {
+                                    if (W::is_signed && weight == internal::solver_weight<W,Trace_Type::ShortestFixedPoint>::bottom()) {
                                         json_out.entry("weight", "negative infinity");
                                     } else {
                                         json_out.entry("weight", weight);

--- a/src/pdaaal-bin/Verifier.h
+++ b/src/pdaaal-bin/Verifier.h
@@ -257,8 +257,42 @@ namespace pdaaal {
                         break;
                     }
                     case 3: {
-                        assert(false);
-                        throw std::runtime_error("Cannot use fixed-point (longest or shortest) trace, not implemented for post* and dual* engine.");
+                        if constexpr(pda_t::has_weight) {
+                            auto instance_copy = instance.copy();
+                            if (trace_type == Trace_Type::Longest) {
+                                bool used_pre_star;
+                                std::tie(result, used_pre_star) = Solver::interleaving_fixed_point_accepts<Trace_Type::Longest>(instance, instance_copy);
+                                if (result) {
+                                    typename pda_t::weight_type weight;
+                                    std::tie(trace, weight) = Solver::get_trace<Trace_Type::Longest>(used_pre_star ? instance_copy : instance);
+                                    reachability_time.stop(); // We don't want to include time for output in reachability_time.
+                                    using W = typename pda_t::weight;
+                                    if (weight == internal::solver_weight<W,Trace_Type::Longest>::bottom()) {
+                                        json_out.entry("weight", "infinity");
+                                    } else {
+                                        json_out.entry("weight", weight);
+                                    }
+                                }
+                            } else { // (trace_type == Trace_Type::ShortestFixedPoint)
+                                bool used_pre_star;
+                                std::tie(result, used_pre_star) = Solver::interleaving_fixed_point_accepts<Trace_Type::ShortestFixedPoint>(instance, instance_copy);
+                                if (result) {
+                                    typename pda_t::weight_type weight;
+                                    std::tie(trace, weight) = Solver::get_trace<Trace_Type::ShortestFixedPoint>(used_pre_star ? instance_copy : instance);
+                                    reachability_time.stop(); // We don't want to include time for output in reachability_time.
+                                    using W = typename pda_t::weight;
+                                    if (W::is_signed && weight == internal::solver_weight<W,Trace_Type::ShortestFixedPoint>::bottom()) {
+                                        json_out.entry("weight", "negative infinity");
+                                    } else {
+                                        json_out.entry("weight", weight);
+                                    }
+                                }
+                            }
+                        } else {
+                            assert(false);
+                            throw std::runtime_error("Cannot use fixed-point (longest or shortest) trace option for unweighted PDA.");
+                        }
+                        break;
                     }
                     default: {
                         std::stringstream error;


### PR DESCRIPTION
Implement post* fixed-point algorithm (to support longest trace).
Add interleaving for longest trace (use options -e 3 -t 3).
Dynamically update fixed-point round-limit to actual number of transitions (rather than the max possible number).
Fix performance bug in fixed_point_workset (remove duplicates from set).
Fix bug, where 0 was intepreted as -inf.