### PR TITLE
Fix post* shortest trace (Dijkstra version)

### DIFF
--- a/src/include/pdaaal/PAutomatonProduct.h
+++ b/src/include/pdaaal/PAutomatonProduct.h
@@ -79,36 +79,6 @@ namespace pdaaal {
                             _swap_initial_final ? _final : _initial,
                             _swap_initial_final ? _initial : _final);
         }
-        template<bool edge_in_first = true>
-        void update_edge_product(size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) {
-            const auto& fast_lookup = constexpr_ternary<edge_in_first>(_id_fast_lookup, _id_fast_lookup_back);
-            std::vector<std::pair<size_t,size_t>> from_states;
-            if (from < fast_lookup.size()) { // Avoid out-of-bounds.
-                from_states = fast_lookup[from];
-            }
-            if (from < _pda_size) {
-                from_states.emplace_back(from, from); // Initial states are not stored in _id_fast_lookup.
-            }
-            const auto& current = constexpr_ternary<edge_in_first>(_initial, _final);
-            const auto& other = constexpr_ternary<edge_in_first>(_final, _initial);
-            auto current_to = current.states()[to].get();
-            std::vector<size_t> waiting;
-            for (auto [other_from, product_from] : from_states) { // Iterate through reachable 'from-states'.
-                if (label == epsilon) {
-                    auto [fresh, product_to] = get_product_state(swap_if<!edge_in_first>(current_to, other.states()[other_from].get()));
-                    assert(!fresh);
-                    _product.update_edge(product_from, product_to, label, trace);
-                } else {
-                    for (const auto& [other_to,other_labels] : other.states()[other_from]->_edges) {
-                        if (other_labels.contains(label)) {
-                            auto [fresh, product_to] = get_product_state(swap_if<!edge_in_first>(current_to, other.states()[other_to].get()));
-                            assert(!fresh);
-                            _product.update_edge(product_from, product_to, label, trace);
-                        }
-                    }
-                }
-            }
-        }
 
         // This is for the dual_search mode:
         bool add_initial_edge(size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) {

--- a/src/include/pdaaal/PAutomatonProduct.h
+++ b/src/include/pdaaal/PAutomatonProduct.h
@@ -346,7 +346,11 @@ namespace pdaaal {
                     }
                 }
             }
-            return _product.has_accepting_state();
+            if constexpr(W::is_weight && trace_type == Trace_Type::Shortest) {
+                return !internal::solver_weight<W,trace_type>::less(et_param, _product.min_accepting_weight());
+            } else {
+                return _product.has_accepting_state();
+            }
         }
 
         static std::vector<size_t> get_initial_accepting(const automaton_t& a1, const automaton_t& a2) {

--- a/src/include/pdaaal/Solver.h
+++ b/src/include/pdaaal/Solver.h
@@ -90,17 +90,17 @@ namespace pdaaal {
                 [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) -> bool {
                     return instance.add_final_edge(from, label, to, trace);
                 },
-                internal::early_termination_handler<W>([&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) -> bool {
+                [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) -> bool {
                     return instance.add_initial_edge(from, label, to, trace);
-                })
+                }
             );
         }
         template <typename W, bool ET=true>
         static bool dual_search(internal::PAutomaton<W> &pre_star_automaton, internal::PAutomaton<W> &post_star_automaton,
                                 const internal::early_termination_fn<W>& pre_star_early_termination,
-                                internal::early_termination_handler<W>&& post_star_early_termination) {
+                                const internal::early_termination_fn<W>& post_star_early_termination) {
             internal::PreStarSaturation<W,ET> pre_star(pre_star_automaton, pre_star_early_termination);
-            internal::PostStarSaturation<W,ET> post_star(post_star_automaton, std::move(post_star_early_termination));
+            internal::PostStarSaturation<W,ET> post_star(post_star_automaton, post_star_early_termination);
             if constexpr (ET) {
                 if (pre_star.found() || post_star.found()) return true;
             }
@@ -155,10 +155,10 @@ namespace pdaaal {
         static bool post_star_accepts(internal::PAutomaton<W> &automaton, size_t state, const std::vector<uint32_t> &stack) {
             if (stack.size() == 1) {
                 auto s_label = stack[0];
-                return automaton.accepts(state, stack) || post_star<trace_type,W,true>(automaton, internal::early_termination_handler<W>(
-                    [&automaton, state, s_label](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W>) -> bool {
-                        return from == state && label == s_label && automaton.states()[to]->_accepting;
-                    }));
+                return automaton.accepts(state, stack) ||
+                       post_star<trace_type,W,true>(automaton, [&automaton, state, s_label](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W>) -> bool {
+                           return from == state && label == s_label && automaton.states()[to]->_accepting;
+                       });
             } else {
                 return post_star<trace_type,W>(automaton) || automaton.accepts(state, stack);
             }
@@ -167,25 +167,21 @@ namespace pdaaal {
         template <Trace_Type trace_type = Trace_Type::Any, typename pda_t, typename automaton_t, typename W>
         static bool post_star_accepts(PAutomatonProduct<pda_t,automaton_t,W>& instance) {
             return instance.initialize_product() ||
-                    post_star<trace_type,W,true>(instance.automaton(), internal::early_termination_handler<W>(
-                       [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) -> bool {
-                           return instance.template add_edge_product<trace_type != Trace_Type::Shortest>(from, label, to, trace);
-                       },
-                       [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) {
-                           instance.update_edge_product(from, label, to, trace);
-                       }));
+                   post_star<trace_type,W,true>(instance.automaton(), [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) -> bool {
+                       return instance.template add_edge_product<trace_type != Trace_Type::Shortest>(from, label, to, trace);
+                   });
         }
 
         template <Trace_Type trace_type = Trace_Type::Any, typename W, bool ET = false>
         static bool post_star(internal::PAutomaton<W> &automaton,
-                              internal::early_termination_handler<W> early_termination = internal::early_termination_handler<W>()) {
+                              const internal::early_termination_fn<W>& early_termination = [](size_t, uint32_t, size_t, internal::edge_annotation_t<W>) -> bool { return false; }) {
             static_assert(is_weighted<W> || trace_type != Trace_Type::Shortest, "Cannot do shortest-trace post* for PDA without weights."); // TODO: Consider: W=uin32_t, weight==1 as a default weight.
             if constexpr (is_weighted<W> && trace_type == Trace_Type::Shortest) {
-                internal::PostStarShortestSaturation<W,true,ET> saturation(automaton, std::move(early_termination));
+                internal::PostStarShortestSaturation<W,true,ET> saturation(automaton, early_termination);
                 return saturation.run();
             } else if constexpr (trace_type == Trace_Type::Any ||
                                  trace_type == Trace_Type::None) { // TODO: Implement faster no-trace option.
-                internal::PostStarSaturation<W,ET> saturation(automaton, std::move(early_termination));
+                internal::PostStarSaturation<W,ET> saturation(automaton, early_termination);
                 return saturation.run();
             }
         }

--- a/src/include/pdaaal/Solver.h
+++ b/src/include/pdaaal/Solver.h
@@ -151,37 +151,35 @@ namespace pdaaal {
             return saturation.found();
         }
 
-        template <Trace_Type trace_type = Trace_Type::Any, typename W>
-        static bool post_star_accepts(internal::PAutomaton<W> &automaton, size_t state, const std::vector<uint32_t> &stack) {
-            if (stack.size() == 1) {
-                auto s_label = stack[0];
-                return automaton.accepts(state, stack) ||
-                       post_star<trace_type,W,true>(automaton, [&automaton, state, s_label](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W>) -> bool {
-                           return from == state && label == s_label && automaton.states()[to]->_accepting;
-                       });
-            } else {
-                return post_star<trace_type,W>(automaton) || automaton.accepts(state, stack);
-            }
-        }
-
         template <Trace_Type trace_type = Trace_Type::Any, typename pda_t, typename automaton_t, typename W>
         static bool post_star_accepts(PAutomatonProduct<pda_t,automaton_t,W>& instance) {
-            return instance.initialize_product() ||
-                   post_star<trace_type,W,true>(instance.automaton(), [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) -> bool {
-                       return instance.template add_edge_product<trace_type != Trace_Type::Shortest>(from, label, to, trace);
-                   });
-        }
-
-        template <Trace_Type trace_type = Trace_Type::Any, typename W, bool ET = false>
-        static bool post_star(internal::PAutomaton<W> &automaton,
-                              const internal::early_termination_fn<W>& early_termination = [](size_t, uint32_t, size_t, internal::edge_annotation_t<W>) -> bool { return false; }) {
+            if (instance.template initialize_product<false,true,trace_type>()) return true;
             static_assert(is_weighted<W> || trace_type != Trace_Type::Shortest, "Cannot do shortest-trace post* for PDA without weights."); // TODO: Consider: W=uin32_t, weight==1 as a default weight.
             if constexpr (is_weighted<W> && trace_type == Trace_Type::Shortest) {
-                internal::PostStarShortestSaturation<W,true,ET> saturation(automaton, early_termination);
+                internal::PostStarShortestSaturation<W,true,true> saturation(instance.automaton(),
+                    [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace, const auto& et_param) -> bool {
+                        return instance.template add_edge_product<true,trace_type>(from, label, to, trace, et_param);
+                    });
                 return saturation.run();
             } else if constexpr (trace_type == Trace_Type::Any ||
                                  trace_type == Trace_Type::None) { // TODO: Implement faster no-trace option.
-                internal::PostStarSaturation<W,ET> saturation(automaton, early_termination);
+                internal::PostStarSaturation<W,true> saturation(instance.automaton(),
+                    [&instance](size_t from, uint32_t label, size_t to, internal::edge_annotation_t<W> trace) -> bool {
+                        return instance.template add_edge_product<true,trace_type>(from, label, to, trace);
+                    });
+                return saturation.run();
+            }
+        }
+
+        template <Trace_Type trace_type = Trace_Type::Any, typename W>
+        static bool post_star(internal::PAutomaton<W> &automaton) {
+            static_assert(is_weighted<W> || trace_type != Trace_Type::Shortest, "Cannot do shortest-trace post* for PDA without weights."); // TODO: Consider: W=uin32_t, weight==1 as a default weight.
+            if constexpr (is_weighted<W> && trace_type == Trace_Type::Shortest) {
+                internal::PostStarShortestSaturation<W,true,false> saturation(automaton);
+                return saturation.run();
+            } else if constexpr (trace_type == Trace_Type::Any ||
+                                 trace_type == Trace_Type::None) { // TODO: Implement faster no-trace option.
+                internal::PostStarSaturation<W,false> saturation(automaton);
                 return saturation.run();
             }
         }
@@ -194,7 +192,7 @@ namespace pdaaal {
         }
         template <Trace_Type trace_type = Trace_Type::Any, typename pda_t, typename automaton_t, typename W>
         static bool post_star_accepts_no_ET(PAutomatonProduct<pda_t,automaton_t,W>& instance) {
-            post_star<trace_type,W,false>(instance.automaton());
+            post_star(instance.automaton());
             return instance.template initialize_product<false,false>();
         }
 

--- a/src/include/pdaaal/cegar/Refinement.h
+++ b/src/include/pdaaal/cegar/Refinement.h
@@ -27,6 +27,7 @@
 #ifndef PDAAAL_REFINEMENT_H
 #define PDAAAL_REFINEMENT_H
 
+#include "pdaaal/utils/more_algorithms.h"
 #include <vector>
 #include <array>
 #include <algorithm>
@@ -36,44 +37,6 @@
 #include <iterator>
 
 namespace pdaaal {
-
-    // Auxiliary function... Why is something like this not in <algorithm>??.
-    template<typename T>
-    inline bool is_disjoint(const std::vector<T>& a, const std::vector<T>& b) {
-        // Inspired by: https://stackoverflow.com/a/29123390
-        assert(std::is_sorted(a.begin(), a.end()));
-        assert(std::is_sorted(b.begin(), b.end()));
-        auto it_a = a.begin();
-        auto it_b = b.begin();
-        while (it_a != a.end() && it_b != b.end()) {
-            if (*it_a < *it_b) {
-                it_a = std::lower_bound(++it_a, a.end(), *it_b);
-            } else if (*it_b < *it_a) {
-                it_b = std::lower_bound(++it_b, b.end(), *it_a);
-            } else {
-                return false;
-            }
-        }
-        return true;
-    }
-    template<typename T, typename U, typename Compare>
-    inline bool is_disjoint(const std::vector<T>& a, const std::vector<U>& b, Compare comp) {
-        // Inspired by: https://stackoverflow.com/a/29123390
-        assert(std::is_sorted(a.begin(), a.end(), comp));
-        assert(std::is_sorted(b.begin(), b.end(), comp));
-        auto it_a = a.begin();
-        auto it_b = b.begin();
-        while (it_a != a.end() && it_b != b.end()) {
-            if (comp(*it_a,*it_b)) {
-                it_a = std::lower_bound(++it_a, a.end(), *it_b, comp);
-            } else if (comp(*it_b, *it_a)) {
-                it_b = std::lower_bound(++it_b, b.end(), *it_a, comp);
-            } else {
-                return false;
-            }
-        }
-        return true;
-    }
 
     template<typename T>
     class Refinement {
@@ -230,22 +193,6 @@ namespace pdaaal {
         const std::vector<Refinement<label_t>>& refinements() const {
             return _refinements;
         }
-    };
-
-    template<typename A, typename B>
-    struct CompFirst {
-        bool operator()(const std::pair<A, B>& lhs, const std::pair<A, B>& rhs) const { return lhs.first < rhs.first; }
-        bool operator()(const std::pair<A, B>& lhs, const A& rhs) const { return lhs.first < rhs; }
-        bool operator()(const A& lhs, const std::pair<A, B>& rhs) const { return lhs < rhs.first; }
-        bool operator()(const A& lhs, const A& rhs) const { return lhs < rhs; }
-    };
-
-    template<typename A, typename B>
-    struct EqFirst {
-        bool operator()(const std::pair<A, B>& lhs, const std::pair<A, B>& rhs) const { return lhs.first == rhs.first; }
-        bool operator()(const std::pair<A, B>& lhs, const A& rhs) const { return lhs.first == rhs; }
-        bool operator()(const A& lhs, const std::pair<A, B>& rhs) const { return lhs == rhs.first; }
-        bool operator()(const A& lhs, const A& rhs) const { return lhs == rhs; }
     };
 
     template<typename A, typename B>

--- a/src/include/pdaaal/internal/PAutomaton.h
+++ b/src/include/pdaaal/internal/PAutomaton.h
@@ -662,9 +662,6 @@ namespace pdaaal::internal {
         auto emplace_edge(size_t from, uint32_t label, size_t to, edge_anno_t trace = edge_anno::make_default()) {
             return _states[from]->_edges.emplace(to, label, trace);
         }
-        auto insert_or_assign_edge(size_t from, uint32_t label, size_t to, edge_anno_t trace = edge_anno::make_default()) {
-            return _states[from]->_edges.insert_or_assign(to, label, trace);
-        }
         void update_edge(size_t from, size_t to, uint32_t label, edge_annotation_t<W,TraceInfoType::Single> trace) {
             auto ptr = _states[from]->_edges.get(to, label);
             assert(ptr != nullptr);

--- a/src/include/pdaaal/internal/PdaSaturation.h
+++ b/src/include/pdaaal/internal/PdaSaturation.h
@@ -59,6 +59,8 @@ namespace pdaaal::internal {
 
     template <typename W>
     using early_termination_fn = std::function<bool(size_t,uint32_t,size_t,edge_annotation_t<W>)>;
+    template <typename W>
+    using early_termination_fn2 = std::function<bool(size_t,uint32_t,size_t,edge_annotation_t<W>,std::conditional_t<W::is_weight, typename W::type, bool> const&)>;
 
     template <typename W, bool ET=false>
     class PreStarSaturation {
@@ -369,7 +371,7 @@ namespace pdaaal::internal {
         };
 
     public:
-        explicit PostStarShortestSaturation(p_automaton_t& automaton, const early_termination_fn<W>& early_termination = [](size_t, uint32_t, size_t, edge_annotation_t<W>) -> bool { return false; })
+        explicit PostStarShortestSaturation(p_automaton_t& automaton, const early_termination_fn2<W>& early_termination = [](size_t, uint32_t, size_t, edge_annotation_t<W>,auto) -> bool { return false; })
                 : _automaton(automaton), _early_termination(early_termination), _pda_states(_automaton.pda().states()),
                   _n_pda_states(_pda_states.size()), _n_Q(_automaton.states().size()) {
             assert(!has_negative_weight());
@@ -381,7 +383,7 @@ namespace pdaaal::internal {
 
     private:
         p_automaton_t& _automaton;
-        const early_termination_fn<W>& _early_termination;
+        const early_termination_fn2<W>& _early_termination;
         const std::vector<typename PDA<W>::state_t>& _pda_states;
         const size_t _n_pda_states;
         const size_t _n_Q;
@@ -452,7 +454,7 @@ namespace pdaaal::internal {
                         } else {
                             insert_rel(from->_id, label, to);
                             if constexpr (ET) {
-                                _found |= _early_termination(from->_id, label, to, trace);
+                                _found |= _early_termination(from->_id, label, to, trace, W::zero());
                             }
                         }
                     }
@@ -512,7 +514,7 @@ namespace pdaaal::internal {
                 _automaton.add_edge(t._from, t._to, t._label, std::make_pair(elem._trace, t_weight));
             }
             if constexpr (ET) {
-                _found |= _early_termination(t._from, t._label, t._to, std::make_pair(elem._trace, t_weight));
+                _found |= _early_termination(t._from, t._label, t._to, std::make_pair(elem._trace, t_weight), elem._weight);
             }
             if (t._from >= _n_pda_states) {
                 assert(t._from >= _n_Q);

--- a/src/include/pdaaal/utils/more_algorithms.h
+++ b/src/include/pdaaal/utils/more_algorithms.h
@@ -29,7 +29,10 @@
 
 #include <utility>
 #include <vector>
+#include <queue>
 #include <algorithm>
+#include <unordered_set>
+#include <cassert>
 
 namespace pdaaal {
     // Auxiliary function... Why is something like this not in <algorithm>??.
@@ -107,9 +110,9 @@ namespace pdaaal {
         void pop() {
             assert(!_seen.contains(_queue.top().second)); // This should be the class invariant.
             _seen.emplace(_queue.top().second);
-            _queue.pop_back();
-            while(_seen.contains(_queue.top().second)) {
-                _queue.pop_back(); // Remove elems already processed.
+            _queue.pop();
+            while(!_queue.empty() && _seen.contains(_queue.top().second)) {
+                _queue.pop(); // Remove elems already processed.
             }
         }
         [[nodiscard]] auto top() const {

--- a/src/include/pdaaal/utils/more_algorithms.h
+++ b/src/include/pdaaal/utils/more_algorithms.h
@@ -1,0 +1,132 @@
+/* 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *  Copyright Morten K. Schou
+ */
+
+/* 
+ * File:   more_algorithms.h
+ * Author: Morten K. Schou <morten@h-schou.dk>
+ *
+ * Created on 06-05-2022.
+ */
+
+#ifndef PDAAAL_MORE_ALGORITHMS_H
+#define PDAAAL_MORE_ALGORITHMS_H
+
+#include <utility>
+#include <vector>
+#include <algorithm>
+
+namespace pdaaal {
+    // Auxiliary function... Why is something like this not in <algorithm>??.
+    template<typename T>
+    inline bool is_disjoint(const std::vector<T>& a, const std::vector<T>& b) {
+        // Inspired by: https://stackoverflow.com/a/29123390
+        assert(std::is_sorted(a.begin(), a.end()));
+        assert(std::is_sorted(b.begin(), b.end()));
+        auto it_a = a.begin();
+        auto it_b = b.begin();
+        while (it_a != a.end() && it_b != b.end()) {
+            if (*it_a < *it_b) {
+                it_a = std::lower_bound(++it_a, a.end(), *it_b);
+            } else if (*it_b < *it_a) {
+                it_b = std::lower_bound(++it_b, b.end(), *it_a);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    template<typename T, typename U, typename Compare>
+    inline bool is_disjoint(const std::vector<T>& a, const std::vector<U>& b, Compare comp) {
+        // Inspired by: https://stackoverflow.com/a/29123390
+        assert(std::is_sorted(a.begin(), a.end(), comp));
+        assert(std::is_sorted(b.begin(), b.end(), comp));
+        auto it_a = a.begin();
+        auto it_b = b.begin();
+        while (it_a != a.end() && it_b != b.end()) {
+            if (comp(*it_a, *it_b)) {
+                it_a = std::lower_bound(++it_a, a.end(), *it_b, comp);
+            } else if (comp(*it_b, *it_a)) {
+                it_b = std::lower_bound(++it_b, b.end(), *it_a, comp);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    template<typename A, typename B, typename Comp = std::less<A>>
+    struct CompFirst {
+        Comp comp{};
+        constexpr bool operator()(const std::pair<A, B>& lhs, const std::pair<A, B>& rhs) const { return comp(lhs.first,rhs.first); }
+        constexpr bool operator()(const std::pair<A, B>& lhs, const A& rhs) const { return comp(lhs.first,rhs); }
+        constexpr bool operator()(const A& lhs, const std::pair<A, B>& rhs) const { return comp(lhs,rhs.first); }
+        constexpr bool operator()(const A& lhs, const A& rhs) const { return comp(lhs,rhs); }
+    };
+    template<typename A, typename B>
+    struct EqFirst : CompFirst<A,B,std::equal_to<A>> {};
+
+    template<typename A, typename Comp = std::less<A>>
+    struct CompSwapArgs {
+        Comp comp{};
+        constexpr bool operator()(const A& lhs, const A& rhs) const { return comp(rhs,lhs); }
+    };
+
+    /**
+     * A priority queue that doesn't pop the same element twice.
+     */
+    template<typename Weight, typename Elem, typename Comp = std::less<Weight>> // Default to max-heap, use CompSwapArgs<Weight,std::less<Weight>> to make it a min-heap.
+    class priority_set {
+        std::priority_queue<std::pair<Weight,Elem>, std::vector<std::pair<Weight,Elem>>, CompFirst<Weight,Elem,Comp>> _queue{};
+        std::unordered_set<Elem> _seen{};
+    public:
+        template<typename... Args>
+        void emplace(const Weight& weight, Args... args) {
+            _queue.emplace(weight, Elem(std::forward<Args>(args)...));
+        }
+        template<typename... Args>
+        void emplace(Weight&& weight, Args... args) {
+            _queue.emplace(std::move(weight), Elem(std::forward<Args>(args)...));
+        }
+        void pop() {
+            assert(!_seen.contains(_queue.top().second)); // This should be the class invariant.
+            _seen.emplace(_queue.top().second);
+            _queue.pop_back();
+            while(_seen.contains(_queue.top().second)) {
+                _queue.pop_back(); // Remove elems already processed.
+            }
+        }
+        [[nodiscard]] auto top() const {
+            return _queue.top();
+        }
+        [[nodiscard]] bool empty() const {
+            return _queue.empty();
+        }
+
+        // Make it look like a vector<Elem> queue.
+        [[nodiscard]] auto back() const {
+            return top().second;
+        }
+        void pop_back() {
+            return pop();
+        }
+    };
+}
+
+#endif //PDAAAL_MORE_ALGORITHMS_H

--- a/test/PAutomaton_test.cpp
+++ b/test/PAutomaton_test.cpp
@@ -182,9 +182,10 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar4EarlyTermination)
     internal::PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
 
     std::vector<char> test_stack_reachable{'A'};
-    BOOST_CHECK_EQUAL(Solver::post_star_accepts<Trace_Type::Shortest>(automaton, 4, pda.encode_pre(test_stack_reachable)), true);
+    PAutomatonProduct instance(pda, std::move(automaton), internal::PAutomaton(pda, 4, pda.encode_pre(test_stack_reachable)));
+    BOOST_CHECK_EQUAL(Solver::post_star_accepts<Trace_Type::Shortest>(instance), true);
 
-    auto result4A = automaton.accept_path<Trace_Type::Shortest>(4, pda.encode_pre(test_stack_reachable));
+    auto result4A = instance.automaton().accept_path<Trace_Type::Shortest>(4, pda.encode_pre(test_stack_reachable));
     auto distance4A = result4A.second;
     BOOST_CHECK_EQUAL(distance4A, 30);          //Example Derived on whiteboard
 }

--- a/test/Parser_test.cpp
+++ b/test/Parser_test.cpp
@@ -47,7 +47,8 @@ BOOST_AUTO_TEST_CASE(PAutomatonFromJson_OldFormat_Test)
     auto automaton = parsing::PAutomatonJsonParser_Old::parse<>(automaton_stream, pda);
     BOOST_CHECK_EQUAL(automaton.states().size(), 3);
     std::vector<uint32_t> stack; stack.emplace_back(0);
-    bool result = Solver::post_star_accepts(automaton, 0, stack);
+    PAutomatonProduct instance(pda, std::move(automaton), internal::PAutomaton(pda, 0, stack));
+    bool result = Solver::post_star_accepts(instance);
     BOOST_CHECK(result);
 }
 
@@ -67,7 +68,8 @@ BOOST_AUTO_TEST_CASE(PAutomatonFromJson_NewFormat_Test)
     auto automaton = parsing::PAutomatonJsonParser::parse<>(automaton_stream, pda);
     BOOST_CHECK_EQUAL(automaton.states().size(), 3);
     std::vector<uint32_t> stack; stack.emplace_back(0);
-    bool result = Solver::post_star_accepts(automaton, 0, stack);
+    PAutomatonProduct instance(pda, std::move(automaton), internal::PAutomaton(pda, 0, stack));
+    bool result = Solver::post_star_accepts(instance);
     BOOST_CHECK(result);
 }
 

--- a/test/Solver_test.cpp
+++ b/test/Solver_test.cpp
@@ -119,10 +119,11 @@ BOOST_AUTO_TEST_CASE(EarlyTerminationPostStar)
 
     std::vector<char> test_stack_reachable{'B', 'A', 'A', 'A'};
     auto stack_native = pda.encode_pre(test_stack_reachable);
-    auto result = Solver::post_star_accepts(automaton, 1, stack_native);
+    PAutomatonProduct instance(pda, std::move(automaton), internal::PAutomaton(pda, 1, stack_native));
+    auto result = Solver::post_star_accepts(instance);
     BOOST_CHECK_EQUAL(result, true);
 
-    auto trace = Solver::get_trace(pda, automaton, 1, test_stack_reachable);
+    auto trace = Solver::get_trace(pda, instance.automaton(), 1, test_stack_reachable);
     BOOST_CHECK_EQUAL(trace.size(), 7);
 }
 


### PR DESCRIPTION
Reverts earlier attempt to improve post* shortest trace.

Actual fix: Early termination for shortest trace takes the current search distance into account and only terminates if it found a path that is short enough.

First try to fix (not enoug): All transitions are put in the queue, and only added when it is time. This ensures that when a transition is added to the saturation P-automata (and the product automata) the shortest accepting path containing it will not have a weight that is shorter than the current search distance (the recently popped weight from the priority queue).

Explanation of bug: Normal post* can add transitions going from non-initial states directly to the automata, since they don't match with any PDS rules. Old version tried to do this, but had to anyways wait untill the end to add these, since their weight could be updated. The broken attempt tried to add them immediately, and update their weight as needed, but this did not always work with the early termination function that checks for existence of paths in the product automaton. 
